### PR TITLE
Feat/next/forgiving decoder

### DIFF
--- a/src/Ber/Reader.ts
+++ b/src/Ber/Reader.ts
@@ -40,7 +40,7 @@ class ExtendedReader extends Reader {
 			case BERDataTypes.NULL: // Note: No readNull in BER library but writer writes 2 bytes
 				this.readByte(false) // Read past - ASN1.NULL tag 0x05
 				this.readByte(false) // and - 0x00 length
-				return { type: ParameterType.Null, value: null } 
+				return { type: ParameterType.Null, value: null }
 			default:
 				throw new UnimplementedEmberTypeError(tag)
 		}

--- a/src/Ber/Writer.ts
+++ b/src/Ber/Writer.ts
@@ -158,9 +158,9 @@ class ExtendedWriter extends Writer {
 					this.writeBoolean(value.value as boolean, BERDataTypes.BOOLEAN)
 					break
 				case ParameterType.Octets:
-					if (!Buffer.isBuffer(value.value)) { 
+					if (!Buffer.isBuffer(value.value)) {
 						value.value = Buffer.from(`${value.value}`)
-					} 
+					}
 					if (value.value.length) {
 						this.writeByte(BERDataTypes.OCTETSTRING)
 						this.writeLength(0)

--- a/src/encodings/ber/__tests__/Connection.spec.ts
+++ b/src/encodings/ber/__tests__/Connection.spec.ts
@@ -3,6 +3,7 @@ import { Connection, ConnectionOperation, ConnectionDisposition } from '../../..
 import { encodeConnection } from '../encoder/Connection'
 import { decodeConnection } from '../decoder/Connection'
 import { literal } from '../../../types/types'
+import { guarded } from '../decoder/DecodeResult'
 
 describe('encodings/ber/Connection', () => {
 	const connection = literal<Connection>({
@@ -17,7 +18,7 @@ describe('encodings/ber/Connection', () => {
 		encodeConnection(connection, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeConnection(reader)
+		const decoded = guarded(decodeConnection(reader))
 
 		expect(decoded).toEqual(connection)
 	})
@@ -28,7 +29,7 @@ describe('encodings/ber/Connection', () => {
 		encodeConnection(minCon, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeConnection(reader)
+		const decoded = guarded(decodeConnection(reader))
 
 		expect(decoded).toEqual(minCon)
 	})

--- a/src/encodings/ber/__tests__/DecodeResult.spec.ts
+++ b/src/encodings/ber/__tests__/DecodeResult.spec.ts
@@ -1,0 +1,324 @@
+import { literal } from '../../../types/types'
+import {
+	DecodeResult,
+	whatever,
+	guarded,
+	makeResult,
+	defaultDecode,
+	unknownContext,
+	safeSet,
+	check,
+	appendErrors,
+	unexpected,
+	DecodeOptions
+} from '../decoder/DecodeResult'
+
+describe('encodings/ver/DecodeResult - default settings', () => {
+	const goodResult = literal<DecodeResult<number>>({
+		value: 42
+	})
+	const resultEmptyErrors = literal<DecodeResult<number>>({
+		value: 42,
+		errors: []
+	})
+	const resultWithError = literal<DecodeResult<number>>({
+		value: 42,
+		errors: [new Error('decode wibbly wobble: tag was junk')]
+	})
+
+	test('whatever', () => {
+		expect(whatever(goodResult)).toBe(42)
+		expect(whatever(resultEmptyErrors)).toBe(42)
+		expect(whatever(resultWithError)).toBe(42)
+	})
+
+	test('guarded', () => {
+		expect(guarded(goodResult)).toBe(42)
+		expect(guarded(resultEmptyErrors)).toBe(42)
+		expect(() => guarded(resultWithError)).toThrow(/wibbly wobble/)
+	})
+
+	test('makeResult', () => {
+		expect(makeResult(42)).toEqual(resultEmptyErrors)
+		expect(makeResult(42, resultWithError.errors)).toEqual(resultWithError)
+	})
+
+	test('unknownContext - decode result, number tag', () => {
+		const updateMe = Object.assign({}, goodResult)
+		unknownContext(updateMe, 'decode wibbly wobble', 42, defaultDecode)
+		expect(updateMe.errors).toHaveLength(1)
+		expect(updateMe.errors?.toString()).toMatch(/Unexpected BER tag '42'/)
+		expect(updateMe.value).toBe(42)
+	})
+
+	test('unknownContext - decode result, null tag', () => {
+		const updateMe = Object.assign({}, goodResult)
+		unknownContext(updateMe, 'decode wibbly wobble', null, defaultDecode)
+		expect(updateMe.errors).toHaveLength(1)
+		expect(updateMe.errors?.toString()).toMatch(/Unexpected BER tag 'null'/)
+		expect(updateMe.value).toBe(42)
+	})
+
+	test('unknownContext - error array, number tag', () => {
+		const updateMe = new Array<Error>()
+		unknownContext(updateMe, 'decode wibbly wobble', 42, defaultDecode)
+		expect(updateMe).toHaveLength(1)
+		expect(updateMe.toString()).toMatch(/Unexpected BER tag '42'/)
+	})
+
+	test('unknownContext - error array, null tag', () => {
+		const updateMe = new Array<Error>()
+		unknownContext(updateMe, 'decode wibbly wobble', null, defaultDecode)
+		expect(updateMe).toHaveLength(1)
+		expect(updateMe.toString()).toMatch(/Unexpected BER tag 'null'/)
+	})
+
+	test('safeSet - no error', () => {
+		const result = Object.assign({}, goodResult)
+		const update = makeResult([41])
+		expect(
+			safeSet(result, update, (x, y) => {
+				y.push(x)
+				return y
+			})
+		).toEqual({
+			value: [41, 42],
+			errors: []
+		})
+	})
+
+	test('safeSet - empty error', () => {
+		const result = Object.assign({}, resultEmptyErrors)
+		const update = makeResult([41])
+		expect(
+			safeSet(result, update, (x, y) => {
+				y.push(x)
+				return y
+			})
+		).toEqual({
+			value: [41, 42],
+			errors: []
+		})
+	})
+
+	test('safeSet - wtih source error', () => {
+		const result = Object.assign({}, resultWithError)
+		const update = makeResult([41])
+		expect(
+			safeSet(result, update, (x, y) => {
+				y.push(x)
+				return y
+			})
+		).toEqual({
+			value: [41, 42],
+			errors: resultWithError.errors
+		})
+	})
+
+	test('safeSet - wtih target error', () => {
+		const result = Object.assign({}, goodResult)
+		const update = makeResult([41], [new Error(`Second error`)])
+		expect(
+			safeSet(result, update, (x, y) => {
+				y.push(x)
+				return y
+			})
+		).toEqual({
+			value: [41, 42],
+			errors: [new Error(`Second error`)]
+		})
+	})
+
+	test('safeSet - wtih source & target error', () => {
+		const result = Object.assign({}, resultWithError)
+		const update = makeResult([41], [new Error(`Second error`)])
+		expect(
+			safeSet(result, update, (x, y) => {
+				y.push(x)
+				return y
+			})
+		).toEqual({
+			value: [41, 42],
+			errors: [new Error(`Second error`), resultWithError.errors![0]] // eslint-disable-line @typescript-eslint/no-non-null-assertion
+		})
+		expect(resultWithError.errors).toHaveLength(1)
+	})
+
+	test('check - decode result, good value', () => {
+		let id: number | null = 84
+		const result = Object.assign({}, goodResult)
+		id = check(id, 'decode wibbly wobble', 'id', -1, result, defaultDecode)
+		expect(id).toBe(84)
+		expect(result.errors).toBeUndefined()
+	})
+
+	test('check - decode result, null value', () => {
+		let id: number | null = null
+		const result = Object.assign({}, goodResult)
+		id = check(id, 'decode wibbly wobble', 'id', -1, result, defaultDecode)
+		expect(id).toBe(-1)
+		expect(result.errors).toHaveLength(1)
+		expect(result.errors?.toString()).toMatch(/For required property 'id', value is missing/)
+	})
+
+	test('check - error array, good value', () => {
+		let id: number | undefined = 84
+		const result = new Array<Error>()
+		id = check(id, 'decode wibbly wobble', 'id', -1, result, defaultDecode)
+		expect(id).toBe(84)
+		expect(result).toHaveLength(0)
+	})
+
+	test('check - error array, null value', () => {
+		let id: number | undefined = undefined
+		const result = new Array<Error>()
+		id = check(id, 'decode wibbly wobble', 'id', -1, result, defaultDecode)
+		expect(id).toBe(-1)
+		expect(result).toHaveLength(1)
+		expect(result.toString()).toMatch(/For required property 'id', value is missing/)
+	})
+
+	test('appendErrors - extract, no change', () => {
+		const source = Object.assign({}, goodResult)
+		const base = Object.assign({}, resultWithError)
+		expect(appendErrors(source, base)).toBe(42)
+		expect(source).toEqual(goodResult)
+		expect(base).toEqual(resultWithError)
+	})
+
+	test('appendErrors - extract, new error on empty', () => {
+		const source = Object.assign({}, resultWithError)
+		const base = Object.assign({}, goodResult)
+		expect(appendErrors(source, base)).toBe(42)
+		expect(source).toEqual(resultWithError)
+		expect(base).toEqual(resultWithError)
+	})
+
+	test('appendErrors - extract, new error on existing', () => {
+		const source = Object.assign({}, resultWithError)
+		const base = Object.assign({}, resultWithError)
+		expect(appendErrors(source, base)).toBe(42)
+		expect(source).toEqual(resultWithError)
+		expect(base.errors).toHaveLength(2)
+		expect(base.errors![0]).toEqual(base.errors![1]) // eslint-disable-line @typescript-eslint/no-non-null-assertion
+	})
+
+	test('unexpected - decode result', () => {
+		const updateMe = Object.assign({}, goodResult)
+		expect(
+			unexpected(updateMe, 'decode wibbly wobble', 'a message to you', 99, defaultDecode)
+		).toEqual(makeResult(99, [new Error('decode wibbly wobble: a message to you')]))
+	})
+
+	test('unexpected - error array', () => {
+		const updateMe = new Array<Error>()
+		expect(
+			unexpected(updateMe, 'decode wibbly wobble', 'a message to you', 99, defaultDecode)
+		).toEqual(makeResult(99, [new Error('decode wibbly wobble: a message to you')]))
+	})
+
+	test('all equal in the end', () => {
+		expect(goodResult).toEqual(
+			literal<DecodeResult<number>>({ value: 42 })
+		)
+		expect(resultEmptyErrors).toEqual(
+			literal<DecodeResult<number>>({
+				value: 42,
+				errors: []
+			})
+		)
+		expect(resultWithError).toEqual(
+			literal<DecodeResult<number>>({
+				value: 42,
+				errors: [new Error('decode wibbly wobble: tag was junk')]
+			})
+		)
+	})
+})
+
+describe('encodings/ver/DecodeResult - expect to throw', () => {
+	const goodResult = literal<DecodeResult<number>>({
+		value: 42
+	})
+
+	const triggerThrow = literal<DecodeOptions>({
+		skipApplicationTags: false,
+		skipContextTags: false,
+		substituteForRequired: false,
+		skipUnexpected: false
+	})
+
+	test('unknownContext - decode result, number tag', () => {
+		const updateMe = Object.assign({}, goodResult)
+		expect(() => unknownContext(updateMe, 'decode wibbly wobble', 42, triggerThrow)).toThrow()
+		expect(updateMe.errors).toBeUndefined()
+	})
+
+	test('unknownContext - decode result, null tag', () => {
+		const updateMe = Object.assign({}, goodResult)
+		expect(() => unknownContext(updateMe, 'decode wibbly wobble', null, triggerThrow)).toThrow()
+		expect(updateMe.errors).toBeUndefined()
+	})
+
+	test('unknownContext - error array, number tag', () => {
+		const updateMe = new Array<Error>()
+		expect(() => unknownContext(updateMe, 'decode wibbly wobble', 42, triggerThrow)).toThrow()
+		expect(updateMe).toHaveLength(0)
+	})
+
+	test('unknownContext - error array, null tag', () => {
+		const updateMe = new Array<Error>()
+		expect(() => unknownContext(updateMe, 'decode wibbly wobble', null, triggerThrow)).toThrow()
+		expect(updateMe).toHaveLength(0)
+	})
+
+	test('check - decode result, good value', () => {
+		let id: number | null = 84
+		const result = Object.assign({}, goodResult)
+		id = check(id, 'decode wibbly wobble', 'id', -1, result, triggerThrow)
+		expect(id).toBe(84)
+		expect(result.errors).toBeUndefined()
+	})
+
+	test('check - decode result, null value', () => {
+		let id: number | null = null
+		const result = Object.assign({}, goodResult)
+		expect(() => {
+			id = check(id, 'decode wibbly wobble', 'id', -1, result, triggerThrow)
+		}).toThrow()
+		expect(id).toBe(null)
+		expect(result.errors).toBeUndefined()
+	})
+
+	test('check - error array, good value', () => {
+		let id: number | undefined = 84
+		const result = new Array<Error>()
+		id = check(id, 'decode wibbly wobble', 'id', -1, result, triggerThrow)
+		expect(id).toBe(84)
+		expect(result).toHaveLength(0)
+	})
+
+	test('check - error array, null value', () => {
+		let id: number | undefined = undefined
+		const result = new Array<Error>()
+		expect(() => {
+			id = check(id, 'decode wibbly wobble', 'id', -1, result, triggerThrow)
+		}).toThrow()
+		expect(id).toBe(undefined)
+		expect(result).toHaveLength(0)
+	})
+
+	test('unexpected - decode result', () => {
+		const updateMe = Object.assign({}, goodResult)
+		expect(() =>
+			unexpected(updateMe, 'decode wibbly wobble', 'a message to you', 99, triggerThrow)
+		).toThrow()
+	})
+
+	test('unexpected - error array', () => {
+		const updateMe = new Array<Error>()
+		expect(() =>
+			unexpected(updateMe, 'decode wibbly wobble', 'a message to you', 99, triggerThrow)
+		).toThrow()
+	})
+})

--- a/src/encodings/ber/__tests__/DecodeResult.spec.ts
+++ b/src/encodings/ber/__tests__/DecodeResult.spec.ts
@@ -10,7 +10,8 @@ import {
 	check,
 	appendErrors,
 	unexpected,
-	DecodeOptions
+	DecodeOptions,
+	unknownApplication
 } from '../decoder/DecodeResult'
 
 describe('encodings/ver/DecodeResult - default settings', () => {
@@ -47,7 +48,7 @@ describe('encodings/ver/DecodeResult - default settings', () => {
 		const updateMe = Object.assign({}, goodResult)
 		unknownContext(updateMe, 'decode wibbly wobble', 42, defaultDecode)
 		expect(updateMe.errors).toHaveLength(1)
-		expect(updateMe.errors?.toString()).toMatch(/Unexpected BER tag '42'/)
+		expect(updateMe.errors?.toString()).toMatch(/Unexpected BER context tag '42'/)
 		expect(updateMe.value).toBe(42)
 	})
 
@@ -55,7 +56,7 @@ describe('encodings/ver/DecodeResult - default settings', () => {
 		const updateMe = Object.assign({}, goodResult)
 		unknownContext(updateMe, 'decode wibbly wobble', null, defaultDecode)
 		expect(updateMe.errors).toHaveLength(1)
-		expect(updateMe.errors?.toString()).toMatch(/Unexpected BER tag 'null'/)
+		expect(updateMe.errors?.toString()).toMatch(/Unexpected BER context tag 'null'/)
 		expect(updateMe.value).toBe(42)
 	})
 
@@ -63,14 +64,44 @@ describe('encodings/ver/DecodeResult - default settings', () => {
 		const updateMe = new Array<Error>()
 		unknownContext(updateMe, 'decode wibbly wobble', 42, defaultDecode)
 		expect(updateMe).toHaveLength(1)
-		expect(updateMe.toString()).toMatch(/Unexpected BER tag '42'/)
+		expect(updateMe.toString()).toMatch(/Unexpected BER context tag '42'/)
 	})
 
 	test('unknownContext - error array, null tag', () => {
 		const updateMe = new Array<Error>()
 		unknownContext(updateMe, 'decode wibbly wobble', null, defaultDecode)
 		expect(updateMe).toHaveLength(1)
-		expect(updateMe.toString()).toMatch(/Unexpected BER tag 'null'/)
+		expect(updateMe.toString()).toMatch(/Unexpected BER context tag 'null'/)
+	})
+
+	test('unknownApplication - decode result, number tag', () => {
+		const updateMe = Object.assign({}, goodResult)
+		unknownApplication(updateMe, 'decode wibbly wobble', 42, defaultDecode)
+		expect(updateMe.errors).toHaveLength(1)
+		expect(updateMe.errors?.toString()).toMatch(/Unexpected BER application tag '42'/)
+		expect(updateMe.value).toBe(42)
+	})
+
+	test('unknownApplication - decode result, null tag', () => {
+		const updateMe = Object.assign({}, goodResult)
+		unknownApplication(updateMe, 'decode wibbly wobble', null, defaultDecode)
+		expect(updateMe.errors).toHaveLength(1)
+		expect(updateMe.errors?.toString()).toMatch(/Unexpected BER application tag 'null'/)
+		expect(updateMe.value).toBe(42)
+	})
+
+	test('unknownApplication - error array, number tag', () => {
+		const updateMe = new Array<Error>()
+		unknownApplication(updateMe, 'decode wibbly wobble', 42, defaultDecode)
+		expect(updateMe).toHaveLength(1)
+		expect(updateMe.toString()).toMatch(/Unexpected BER application tag '42'/)
+	})
+
+	test('unknownApplication - error array, null tag', () => {
+		const updateMe = new Array<Error>()
+		unknownApplication(updateMe, 'decode wibbly wobble', null, defaultDecode)
+		expect(updateMe).toHaveLength(1)
+		expect(updateMe.toString()).toMatch(/Unexpected BER application tag 'null'/)
 	})
 
 	test('safeSet - no error', () => {
@@ -269,6 +300,30 @@ describe('encodings/ver/DecodeResult - expect to throw', () => {
 	test('unknownContext - error array, null tag', () => {
 		const updateMe = new Array<Error>()
 		expect(() => unknownContext(updateMe, 'decode wibbly wobble', null, triggerThrow)).toThrow()
+		expect(updateMe).toHaveLength(0)
+	})
+
+	test('unknownApplication - decode result, number tag', () => {
+		const updateMe = Object.assign({}, goodResult)
+		expect(() => unknownApplication(updateMe, 'decode wibbly wobble', 42, triggerThrow)).toThrow()
+		expect(updateMe.errors).toBeUndefined()
+	})
+
+	test('unknownApplication - decode result, null tag', () => {
+		const updateMe = Object.assign({}, goodResult)
+		expect(() => unknownApplication(updateMe, 'decode wibbly wobble', null, triggerThrow)).toThrow()
+		expect(updateMe.errors).toBeUndefined()
+	})
+
+	test('unknownApplication - error array, number tag', () => {
+		const updateMe = new Array<Error>()
+		expect(() => unknownApplication(updateMe, 'decode wibbly wobble', 42, triggerThrow)).toThrow()
+		expect(updateMe).toHaveLength(0)
+	})
+
+	test('unknownApplication - error array, null tag', () => {
+		const updateMe = new Array<Error>()
+		expect(() => unknownApplication(updateMe, 'decode wibbly wobble', null, triggerThrow)).toThrow()
 		expect(updateMe).toHaveLength(0)
 	})
 

--- a/src/encodings/ber/__tests__/EmberNode.spec.ts
+++ b/src/encodings/ber/__tests__/EmberNode.spec.ts
@@ -4,6 +4,7 @@ import { encodeNode } from '../encoder/EmberNode'
 import { decodeNode } from '../decoder/EmberNode'
 import { ElementType } from '../../../model/EmberElement'
 import { literal } from '../../../types/types'
+import { guarded } from '../decoder/DecodeResult'
 
 describe('encodings/ber/EmberNode', () => {
 	const en = literal<EmberNode>({
@@ -21,7 +22,7 @@ describe('encodings/ber/EmberNode', () => {
 		encodeNode(en, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeNode(reader)
+		const decoded = guarded(decodeNode(reader))
 
 		expect(decoded).toEqual(en)
 	})

--- a/src/encodings/ber/__tests__/FunctionArgument.spec.ts
+++ b/src/encodings/ber/__tests__/FunctionArgument.spec.ts
@@ -4,6 +4,7 @@ import { encodeFunctionArgument } from '../encoder/FunctionArgument'
 import { decodeFunctionArgument } from '../decoder/FunctionArgument'
 import { ParameterType } from '../../../model/Parameter'
 import { literal } from '../../../types/types'
+import { guarded } from '../decoder/DecodeResult'
 
 describe('encoders/ber/FunctionArgument', () => {
 	const fa = literal<FunctionArgument>({
@@ -16,7 +17,7 @@ describe('encoders/ber/FunctionArgument', () => {
 		encodeFunctionArgument(fa, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeFunctionArgument(reader)
+		const decoded = guarded(decodeFunctionArgument(reader))
 
 		expect(decoded).toEqual(fa)
 	})
@@ -29,7 +30,7 @@ describe('encoders/ber/FunctionArgument', () => {
 		encodeFunctionArgument(noName, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeFunctionArgument(reader)
+		const decoded = guarded(decodeFunctionArgument(reader))
 
 		expect(decoded).toEqual(noName)
 	})

--- a/src/encodings/ber/__tests__/Invocation.spec.ts
+++ b/src/encodings/ber/__tests__/Invocation.spec.ts
@@ -4,6 +4,7 @@ import { encodeInvocation } from '../encoder/Invocation'
 import { decodeInvocation } from '../decoder/Invocation'
 import { ParameterType } from '../../../model/Parameter'
 import { literal } from '../../../types/types'
+import { guarded } from '../decoder/DecodeResult'
 
 describe('encodings/ber/Invocation', () => {
 	const iv = literal<Invocation>({
@@ -29,7 +30,7 @@ describe('encodings/ber/Invocation', () => {
 		encodeInvocation(iv, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeInvocation(reader)
+		const decoded = guarded(decodeInvocation(reader))
 
 		expect(decoded).toEqual(iv)
 	})
@@ -39,7 +40,7 @@ describe('encodings/ber/Invocation', () => {
 		encodeInvocation(noArgs, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeInvocation(reader)
+		const decoded = guarded(decodeInvocation(reader))
 
 		expect(decoded).toEqual(noArgs)
 	})
@@ -49,7 +50,7 @@ describe('encodings/ber/Invocation', () => {
 		encodeInvocation(noId, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeInvocation(reader)
+		const decoded = guarded(decodeInvocation(reader))
 
 		expect(decoded).toEqual(noId)
 	})

--- a/src/encodings/ber/__tests__/InvocationResult.spec.ts
+++ b/src/encodings/ber/__tests__/InvocationResult.spec.ts
@@ -4,6 +4,7 @@ import { encodeInvocationResult } from '../encoder/InvocationResult'
 import { decodeInvocationResult } from '../decoder/InvocationResult'
 import { ParameterType } from '../../../model/Parameter'
 import { literal } from '../../../types/types'
+import { guarded } from '../decoder/DecodeResult'
 
 describe('encodings/ber/InvocationResult', () => {
 	const ir = literal<InvocationResult>({
@@ -25,7 +26,7 @@ describe('encodings/ber/InvocationResult', () => {
 		encodeInvocationResult(ir, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeInvocationResult(reader)
+		const decoded = guarded(decodeInvocationResult(reader))
 
 		expect(decoded).toEqual(ir)
 	})
@@ -35,7 +36,7 @@ describe('encodings/ber/InvocationResult', () => {
 		encodeInvocationResult(voidRes, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeInvocationResult(reader)
+		const decoded = guarded(decodeInvocationResult(reader))
 
 		expect(decoded).toEqual(voidRes)
 	})
@@ -46,7 +47,7 @@ describe('encodings/ber/InvocationResult', () => {
 		encodeInvocationResult({ id: voidRes.id, success: true, result: [] }, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeInvocationResult(reader)
+		const decoded = guarded(decodeInvocationResult(reader))
 
 		expect(decoded).toEqual(voidRes)
 	})

--- a/src/encodings/ber/__tests__/Label.spec.ts
+++ b/src/encodings/ber/__tests__/Label.spec.ts
@@ -3,6 +3,7 @@ import { Label } from '../../../model/Label'
 import { encodeLabel } from '../encoder/Label'
 import { decodeLabel } from '../decoder/Label'
 import { literal } from '../../../types/types'
+import { guarded } from '../decoder/DecodeResult'
 
 describe('encodings/ber/Label', () => {
 	const lbl = literal<Label>({
@@ -15,7 +16,7 @@ describe('encodings/ber/Label', () => {
 		encodeLabel(lbl, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeLabel(reader)
+		const decoded = guarded(decodeLabel(reader))
 
 		expect(decoded).toEqual(lbl)
 	})

--- a/src/encodings/ber/__tests__/Label.spec.ts
+++ b/src/encodings/ber/__tests__/Label.spec.ts
@@ -20,4 +20,30 @@ describe('encodings/ber/Label', () => {
 
 		expect(decoded).toEqual(lbl)
 	})
+
+	test('write and read a label without description', () => {
+		const writer = new Ber.Writer()
+		const badLabel = { basePath: '5.4.3.2.1', description: '' } as Label
+		encodeLabel(badLabel, writer)
+		const badBuffer = writer.buffer.slice(0, writer.buffer.length - 4)
+		badBuffer[1] = badBuffer[1] - 4
+		const reader = new Ber.Reader(badBuffer)
+		const decoded = decodeLabel(reader)
+
+		expect(decoded.value).toEqual(badLabel)
+		expect(decoded.errors).toHaveLength(1)
+	})
+
+	test('write and read a label with unknown context', () => {
+		const writer = new Ber.Writer()
+		encodeLabel(lbl, writer)
+		writer.buffer[11] = Ber.CONTEXT(13)
+		const reader = new Ber.Reader(writer.buffer)
+		const decoded = decodeLabel(reader)
+
+		expect(decoded.value).toEqual(
+			literal<Label>({ basePath: lbl.basePath, description: '' })
+		)
+		expect(decoded.errors).toHaveLength(2)
+	})
 })

--- a/src/encodings/ber/__tests__/Parameter.spec.ts
+++ b/src/encodings/ber/__tests__/Parameter.spec.ts
@@ -5,6 +5,7 @@ import { decodeParameter } from '../decoder/Parameter'
 import { ElementType } from '../../../model/EmberElement'
 import { StreamFormat, StreamDescriptionImpl } from '../../../model/StreamDescription'
 import { literal } from '../../../types/types'
+import { guarded } from '../decoder/DecodeResult'
 
 describe('encodings/ber/Parameter', () => {
 	const prm = literal<Parameter>({
@@ -17,7 +18,7 @@ describe('encodings/ber/Parameter', () => {
 		encodeParameter(prm, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeParameter(reader)
+		const decoded = guarded(decodeParameter(reader))
 
 		expect(decoded).toEqual(prm)
 	}

--- a/src/encodings/ber/__tests__/Parameter.spec.ts
+++ b/src/encodings/ber/__tests__/Parameter.spec.ts
@@ -4,12 +4,13 @@ import { encodeParameter } from '../encoder/Parameter'
 import { decodeParameter } from '../decoder/Parameter'
 import { ElementType } from '../../../model/EmberElement'
 import { StreamFormat, StreamDescriptionImpl } from '../../../model/StreamDescription'
+import { literal } from '../../../types/types'
 
 describe('encodings/ber/Parameter', () => {
-	const prm = {
+	const prm = literal<Parameter>({
 		type: ElementType.Parameter,
 		parameterType: ParameterType.String
-	} as Parameter
+	})
 
 	function roundtripParameter(prm: Parameter): void {
 		const writer = new Ber.Writer()

--- a/src/encodings/ber/__tests__/StreamDescription.spec.ts
+++ b/src/encodings/ber/__tests__/StreamDescription.spec.ts
@@ -3,6 +3,7 @@ import { StreamDescription, StreamFormat } from '../../../model/StreamDescriptio
 import { encodeStreamDescription } from '../encoder/StreamDescription'
 import { decodeStreamDescription } from '../decoder/StreamDescription'
 import { literal } from '../../../types/types'
+import { guarded } from '../decoder/DecodeResult'
 
 describe('encodings/ber/StreamDescription', () => {
 	const sd = literal<StreamDescription>({
@@ -15,7 +16,7 @@ describe('encodings/ber/StreamDescription', () => {
 		encodeStreamDescription(sd, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeStreamDescription(reader)
+		const decoded = guarded(decodeStreamDescription(reader))
 
 		expect(decoded).toEqual(sd)
 	})

--- a/src/encodings/ber/__tests__/StreamEntry.spec.ts
+++ b/src/encodings/ber/__tests__/StreamEntry.spec.ts
@@ -4,6 +4,7 @@ import { encodeStreamEntry } from '../encoder/StreamEntry'
 import { decodeStreamEntry } from '../decoder/StreamEntry'
 import { ParameterType } from '../../../model/Parameter'
 import { literal } from '../../../types/types'
+import { guarded } from '../decoder/DecodeResult'
 
 describe('encodings/ber/StreamEntry', () => {
 	test('write and read stream entry - integer', () => {
@@ -16,7 +17,7 @@ describe('encodings/ber/StreamEntry', () => {
 		encodeStreamEntry(se, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeStreamEntry(reader)
+		const decoded = guarded(decodeStreamEntry(reader))
 
 		expect(decoded).toEqual(se)
 	})
@@ -31,7 +32,7 @@ describe('encodings/ber/StreamEntry', () => {
 		encodeStreamEntry(se, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeStreamEntry(reader)
+		const decoded = guarded(decodeStreamEntry(reader))
 
 		expect(decoded).toEqual(se)
 	})
@@ -46,7 +47,7 @@ describe('encodings/ber/StreamEntry', () => {
 		encodeStreamEntry(se, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeStreamEntry(reader)
+		const decoded = guarded(decodeStreamEntry(reader))
 
 		expect(decoded).toEqual(se)
 	})
@@ -61,7 +62,7 @@ describe('encodings/ber/StreamEntry', () => {
 		encodeStreamEntry(se, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeStreamEntry(reader)
+		const decoded = guarded(decodeStreamEntry(reader))
 
 		expect(decoded).toEqual(se)
 	})
@@ -76,7 +77,7 @@ describe('encodings/ber/StreamEntry', () => {
 		encodeStreamEntry(se, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeStreamEntry(reader)
+		const decoded = guarded(decodeStreamEntry(reader))
 
 		expect(decoded).toEqual(se)
 	})
@@ -91,7 +92,7 @@ describe('encodings/ber/StreamEntry', () => {
 		encodeStreamEntry(se, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeStreamEntry(reader)
+		const decoded = guarded(decodeStreamEntry(reader))
 
 		expect(decoded).toEqual(se)
 	})
@@ -106,7 +107,7 @@ describe('encodings/ber/StreamEntry', () => {
 		encodeStreamEntry(se, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeStreamEntry(reader)
+		const decoded = guarded(decodeStreamEntry(reader))
 
 		expect(decoded).toEqual(se)
 	})
@@ -121,7 +122,7 @@ describe('encodings/ber/StreamEntry', () => {
 		encodeStreamEntry(se, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeStreamEntry(reader)
+		const decoded = guarded(decodeStreamEntry(reader))
 
 		expect(decoded).toEqual(se)
 	})

--- a/src/encodings/ber/__tests__/StringIntegerCollection.spec.ts
+++ b/src/encodings/ber/__tests__/StringIntegerCollection.spec.ts
@@ -2,6 +2,7 @@ import * as Ber from '../../../Ber'
 import { StringIntegerCollection } from '../../../types/types'
 import { encodeStringIntegerCollection } from '../encoder/StringIntegerCollection'
 import { decodeStringIntegerCollection } from '../decoder/StringIntegerCollection'
+import { guarded } from '../decoder/DecodeResult'
 
 describe('encodings/ber/StringIntegerCollection', () => {
 	const sic: StringIntegerCollection = new Map<string, number>([
@@ -15,7 +16,7 @@ describe('encodings/ber/StringIntegerCollection', () => {
 		encodeStringIntegerCollection(sic, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeStringIntegerCollection(reader)
+		const decoded = guarded(decodeStringIntegerCollection(reader))
 
 		expect(decoded).toEqual(sic)
 	})
@@ -27,7 +28,7 @@ describe('encodings/ber/StringIntegerCollection', () => {
 		encodeStringIntegerCollection(emptySic, writer)
 		console.log(writer.buffer)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeStringIntegerCollection(reader)
+		const decoded = guarded(decodeStringIntegerCollection(reader))
 
 		expect(decoded).toEqual(emptySic)
 	})

--- a/src/encodings/ber/__tests__/Template.spec.ts
+++ b/src/encodings/ber/__tests__/Template.spec.ts
@@ -11,6 +11,7 @@ import {
 import { EmberNodeImpl } from '../../../model/EmberNode'
 import { encodeNumberedElement } from '../encoder/Tree'
 import { encodeQualifedElement } from '../encoder/Qualified'
+import { guarded } from '../decoder/DecodeResult'
 
 describe('encodings/ber/Template', () => {
 	function roundtripTemplate(tmpl: TreeElement<Template>, qualified = false): void {
@@ -20,7 +21,7 @@ describe('encodings/ber/Template', () => {
 		console.log(writer.buffer)
 		expect(writer.buffer.length).toBeGreaterThan(0)
 		const reader = new Ber.Reader(writer.buffer)
-		const decoded = decodeTemplate(reader, qualified)
+		const decoded = guarded(decodeTemplate(reader, qualified))
 
 		expect(decoded).toEqual(tmpl)
 	}

--- a/src/encodings/ber/__tests__/index.spec.ts
+++ b/src/encodings/ber/__tests__/index.spec.ts
@@ -4,11 +4,12 @@ import { Root, RootType } from '../../../types/types'
 import { berEncode, berDecode } from '..'
 import { QualifiedElementImpl, NumberedTreeNodeImpl } from '../../../model/Tree'
 import { EmberNodeImpl } from '../../../model/EmberNode'
+import { guarded } from '../decoder/DecodeResult'
 
 describe('encoders/Ber/index', () => {
 	function roundTrip(res: Root, type: RootType): void {
 		const encoded = berEncode(res, type)
-		const decoded = berDecode(encoded)
+		const decoded = guarded(berDecode(encoded))
 
 		expect(decoded).toEqual(res)
 	}

--- a/src/encodings/ber/decoder/DecodeResult.ts
+++ b/src/encodings/ber/decoder/DecodeResult.ts
@@ -9,6 +9,7 @@ export {
 	DecodeError,
 	makeResult,
 	unknownContext,
+	unknownApplication,
 	safeSet,
 	guarded,
 	appendErrors,
@@ -114,9 +115,37 @@ function unknownContext<T>(
 	tag: number | null,
 	options: DecodeOptions = defaultDecode
 ): void {
-	const err = new Error(`${context}: Unexpected BER tag '${tag}'`)
+	const err = new Error(`${context}: Unexpected BER context tag '${tag}'`)
 	let errors = Array.isArray(decres) ? decres : decres.errors
 	if (options.skipContextTags) {
+		if (!errors) {
+			errors = []
+		}
+		errors.push(err)
+		if (!Array.isArray(decres)) {
+			decres.errors = errors
+		}
+	} else {
+		throw err
+	}
+}
+
+/**
+ * Process a decoding problem when an application tag is not recognized.
+ * @param decres Decoding result to add the error to (if appropriate).
+ * @param context Description of where the tag is.
+ * @param tag Unrecognized tag.
+ * @param options Control the processing of the error.
+ */
+function unknownApplication<T>(
+	decres: DecodeResult<T> | Array<Error>,
+	context: string,
+	tag: number | null,
+	options: DecodeOptions = defaultDecode
+): void {
+	const err = new Error(`${context}: Unexpected BER application tag '${tag}'`)
+	let errors = Array.isArray(decres) ? decres : decres.errors
+	if (options.skipApplicationTags) {
 		if (!errors) {
 			errors = []
 		}

--- a/src/encodings/ber/decoder/DecodeResult.ts
+++ b/src/encodings/ber/decoder/DecodeResult.ts
@@ -204,7 +204,7 @@ function check<T>(
 			if (!errors) {
 				errors = []
 			}
-			errors.push(new Error(errMsg + `Substituting '${substitute}`))
+			errors.push(new Error(errMsg + ` Substituting '${substitute}'`))
 			if (!Array.isArray(decres)) {
 				decres.errors = errors
 			}

--- a/src/encodings/ber/decoder/DecodeResult.ts
+++ b/src/encodings/ber/decoder/DecodeResult.ts
@@ -1,0 +1,185 @@
+import { literal } from '../../../types/types'
+
+export {
+	DecodeOptions,
+	defaultDecode,
+	DecodeResult,
+	whatever,
+	check,
+	DecodeError,
+	makeResult,
+	unknownContext,
+	safeSet,
+	guarded,
+	appendErrors,
+	unexpected
+}
+
+/**
+ * Control what cuases an exception during decoding.
+ */
+interface DecodeOptions {
+	/** Skip unknown application tags, used to identify objects. */
+	skipApplicationTags: boolean
+	/** Skip unknown context tags, used to identify the properties of objects. */
+	skipContextTags: boolean
+	/** Substitute a default value when a required value is missing. */
+	substituteForRequired: boolean
+	/** Skip past unexpected enumeration values. */
+	skipUnexpected: boolean
+}
+
+/**
+ * Default decoding values. Prevents throwing exceptions while decoding.
+ */
+const defaultDecode = literal<DecodeOptions>({
+	skipApplicationTags: true,
+	skipContextTags: true,
+	substituteForRequired: true,
+	skipUnexpected: true
+})
+
+/**
+ * Decoders are forgiving and return both a candidate value and a list of
+ * errors found in the source data.
+ */
+interface DecodeResult<T> {
+	/** Candicate decoded value. */
+	value: T
+	/** List of errors, if any, found during decoding. */
+	errors?: Array<Error>
+}
+
+/**
+ * Return the decoded result whatever errors are reported.
+ * @param decres Result of decoding.
+ * @returns Candidate result of decoding, ignoring any errors.
+ */
+function whatever<T>(decres: DecodeResult<T>): T {
+	return decres.value
+}
+
+class DecodeError extends Error {
+	public readonly sub: Array<Error>
+	constructor(errors: Array<Error>) {
+		super(`Decoding failed. Errors are:\n${errors.join('\n')}`)
+		this.sub = errors
+	}
+}
+
+/**
+ * Return the decoded result if no errors, otherwise throw a summary error.
+ * @param decres Result of decoding.
+ * @returns Candidate result of decoding, only if no errors.
+ * @throws Summary when errors exists.
+ */
+function guarded<T>(decres: DecodeResult<T>): T {
+	if (decres.errors && decres.errors.length > 0) {
+		throw new DecodeError(decres.errors)
+	}
+	return decres.value
+}
+
+/**
+ * Make a decoded result from an initial value with an empty list if errors.
+ * @param t Value to embed in the initial result.
+ */
+function makeResult<T>(t: T, errors?: Array<Error>): DecodeResult<T> {
+	return literal<DecodeResult<T>>({
+		value: t,
+		errors: Array.isArray(errors) ? errors : []
+	})
+}
+
+/**
+ * Process a decoding problem when a context parameter tag is not recognized.
+ * @param decres Decoding result to add the error to (if appropriate).
+ * @param context Description of the context.
+ * @param tag Unrecognized tag.
+ * @param options Control the processing of the error.
+ */
+function unknownContext<T>(
+	decres: DecodeResult<T> | Array<Error>,
+	context: string,
+	tag: number | null,
+	options: DecodeOptions = defaultDecode
+): void {
+	const err = new Error(`${context}: Unexpected BER tag '${tag}'`)
+	let errors = Array.isArray(decres) ? decres : decres.errors
+	if (options.skipContextTags) {
+		if (!errors) {
+			errors = []
+		}
+		errors.push(err)
+	} else {
+		throw err
+	}
+}
+
+function safeSet<S, T>(
+	result: DecodeResult<S>,
+	update: DecodeResult<T>,
+	fn: (s: S, t: T) => T
+): DecodeResult<T> {
+	if (result.errors && result.errors.length > 0) {
+		update.errors = update.errors ? update.errors.concat(result.errors) : result.errors
+	} else {
+		update.value = fn(result.value, update.value)
+	}
+	return update
+}
+
+function check<T>(
+	value: T | null | undefined,
+	context: string,
+	propertyName: string,
+	substitute: T,
+	decres: DecodeResult<T> | Array<Error>,
+	options: DecodeOptions = defaultDecode
+): T {
+	if (value === null || value === undefined) {
+		const errMsg = `${context}: For required property '${propertyName}', value is missing.`
+		if (options.substituteForRequired) {
+			let errors = Array.isArray(decres) ? decres : decres.errors
+			if (!errors) {
+				errors = []
+			}
+			errors.push(new Error(errMsg + `Substituting '${substitute}`))
+			return substitute
+		} else {
+			throw new Error(errMsg)
+		}
+	}
+	return value
+}
+
+function appendErrors<T, U>(source: DecodeResult<T>, decres: DecodeResult<U> | Array<Error>): T {
+	if (source.errors && source.errors.length > 0) {
+		if (Array.isArray(decres)) {
+			decres.push(...source.errors)
+		} else {
+			decres.errors = decres.errors ? decres.errors.concat() : source.errors
+		}
+	}
+	return source.value
+}
+
+function unexpected<T>(
+	decres: DecodeResult<T> | Array<Error>,
+	context: string,
+	message = '',
+	substitute: T,
+	options: DecodeOptions = defaultDecode
+): DecodeResult<T> {
+	let errors = Array.isArray(decres) ? decres : decres.errors
+	const err = new Error(`${context}${message ? ': ' + message : ''}`)
+	if (options.skipUnexpected) {
+		if (!errors) {
+			errors = []
+		}
+		errors.push(err)
+		return Array.isArray(decres) ? makeResult(substitute, errors) : decres
+	} else {
+		throw err
+	}
+}

--- a/src/encodings/ber/decoder/EmberFunction.ts
+++ b/src/encodings/ber/decoder/EmberFunction.ts
@@ -1,110 +1,86 @@
 import * as Ber from '../../../Ber'
 // import { EmberFunction, EmberFunctionImpl } from '../../../model/EmberFunction'
-import { EmberFunction } from '../../../model/EmberFunction'
+import { EmberFunction, EmberFunctionImpl } from '../../../model/EmberFunction'
 import { decodeFunctionArgument } from './FunctionArgument'
-// import { EmberTreeNode } from '../../../types/types'
-// import { EmberElement } from '../../../model/EmberElement'
-// import { TreeImpl } from '../../../model/Tree'
-// import { decodeChildren } from './Tree'
-// import { FunctionBERID } from '../constants'
+import {
+	DecodeOptions,
+	defaultDecode,
+	DecodeResult,
+	unknownContext,
+	makeResult,
+	appendErrors
+} from './DecodeResult'
+import { FunctionArgument } from '../../../model/FunctionArgument'
+import { RelativeOID } from '../../../types/types'
 
-// export { decodeFunction, decodeFunctionContent }
 export { decodeFunctionContent }
 
-// function decodeFunction(reader: Ber.Reader): EmberTreeNode<EmberFunction> {
-// 	const ber = reader.getSequence(FunctionBERID)
-// 	let number: number | null = null
-// 	let contents: EmberFunction | null = null
-// 	let kids: Array<EmberTreeNode<EmberElement>> | undefined = undefined
-// 	while (ber.remain) {
-// 		const tag = ber.peek()
-// 		const seq = ber.getSequence(tag!)
-// 		switch (tag) {
-// 			case Ber.CONTEXT(0):
-// 				number = seq.readInt()
-// 			  break
-// 			case Ber.CONTEXT(1):
-// 				contents = decodeFunctionContent(seq)
-// 				break
-// 			case Ber.CONTEXT(2):
-// 				kids = decodeChildren(seq)
-// 			  break
-// 			default:
-// 			  throw new Error(``)
-// 		}
-// 	}
-// 	if (number === null) {
-// 		throw new Error(``)
-// 	}
-// 	if (contents === null) {
-// 		return new TreeImpl(
-// 			new EmberFunctionImpl(),
-// 			undefined,
-// 			kids
-// 		)
-// 	}
-// 	return new TreeImpl(
-// 		new EmberFunctionImpl(
-// 			contents.identifier,
-// 			contents.description,
-// 			contents.args,
-// 			contents.result,
-// 			contents.templateReference
-// 		),
-// 		undefined,
-// 		kids
-// 	)
-// }
-
-function decodeFunctionContent(reader: Ber.Reader): EmberFunction {
-	const f: EmberFunction = {} as EmberFunction
+function decodeFunctionContent(
+	reader: Ber.Reader,
+	options: DecodeOptions = defaultDecode
+): DecodeResult<EmberFunction> {
 	const ber = reader.getSequence(Ber.BERDataTypes.SET)
 	let readArgSeq: Ber.Reader
 	let readResSeq: Ber.Reader
+	let identifier: string | undefined = undefined
+	let description: string | undefined = undefined
+	let args: Array<FunctionArgument> | undefined = undefined
+	let result: Array<FunctionArgument> | undefined = undefined
+	let templateReference: RelativeOID | undefined = undefined
+	const errors: Array<Error> = []
 	while (ber.remain > 0) {
 		const tag = ber.peek()
 		if (tag === null) {
-			throw new Error(``)
+			unknownContext(errors, 'decode function content', tag, options)
+			continue
 		}
 		const seq = ber.getSequence(tag)
 		switch (tag) {
 			case Ber.CONTEXT(0):
-				f.identifier = seq.readString(Ber.BERDataTypes.STRING)
+				identifier = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			case Ber.CONTEXT(1):
-				f.description = seq.readString(Ber.BERDataTypes.STRING)
+				description = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			case Ber.CONTEXT(2):
-				f.args = []
+				args = []
 				readArgSeq = seq.getSequence(Ber.BERDataTypes.SEQUENCE)
 				while (readArgSeq.remain > 0) {
 					const argTag = readArgSeq.peek() // TODO check this
 					if (argTag !== Ber.CONTEXT(0)) {
-						throw new Error(``)
+						unknownContext(errors, 'decode function content: arguments', argTag, options)
+						continue
 					}
 					const argSeq = readArgSeq.getSequence(Ber.CONTEXT(0))
-					f.args.push(decodeFunctionArgument(argSeq))
+					const argEl = appendErrors(decodeFunctionArgument(argSeq, options), errors)
+					args.push(argEl)
 				}
 				break
 			case Ber.CONTEXT(3):
-				f.result = []
+				result = []
 				readResSeq = seq.getSequence(Ber.BERDataTypes.SEQUENCE)
 				while (readResSeq.remain > 0) {
 					const resTag = readResSeq.peek()
 					if (resTag !== Ber.CONTEXT(0)) {
-						throw new Error(``)
+						unknownContext(errors, 'decode function content: result', resTag, options)
+						continue
 					}
 					const resSeq = readResSeq.getSequence(Ber.CONTEXT(0))
-					f.result.push(decodeFunctionArgument(resSeq))
+					const resEl = appendErrors(decodeFunctionArgument(resSeq, options), errors)
+					result.push(resEl)
 				}
 				break
 			case Ber.CONTEXT(4):
-				f.templateReference = seq.readRelativeOID(Ber.BERDataTypes.RELATIVE_OID)
+				templateReference = seq.readRelativeOID(Ber.BERDataTypes.RELATIVE_OID)
 				break
 			default:
-				throw new Error(``)
+				unknownContext(errors, 'decode function content', tag, options)
+				break
 		}
 	}
 
-	return f
+	return makeResult(
+		new EmberFunctionImpl(identifier, description, args, result, templateReference),
+		errors
+	)
 }

--- a/src/encodings/ber/decoder/EmberNode.ts
+++ b/src/encodings/ber/decoder/EmberNode.ts
@@ -1,94 +1,68 @@
 import * as Ber from '../../../Ber'
 import { EmberNode, EmberNodeImpl } from '../../../model/EmberNode'
-// import { decodeChildren } from './Tree'
-// import { EmberTreeNode } from '../../../types/types'
-// import { TreeImpl } from '../../../model/Tree'
-// import { EmberElement } from '../../../model/EmberElement'
-// import { NodeBERID } from '../constants'
+import {
+	DecodeOptions,
+	defaultDecode,
+	DecodeResult,
+	unknownContext,
+	makeResult
+} from './DecodeResult'
+import { RelativeOID } from '../../../types/types'
 
 export { decodeNode }
 
-// function decodeNode(reader: Ber.Reader): EmberTreeNode<EmberNode> {
-// 	const ber = reader.getSequence(NodeBERID)
-// 	let number: number | null = null
-// 	let contents: EmberNode | null = null
-// 	let kids: Array<EmberTreeNode<EmberElement>> | undefined = undefined
-// 	while (ber.remain > 0) {
-// 		const tag = ber.peek()
-// 		const seq = ber.getSequence(tag!)
-// 		switch (tag) {
-// 			case Ber.CONTEXT(0):
-// 				number = seq.readInt()
-// 			  break
-// 			case Ber.CONTEXT(1):
-// 				contents = decodeNodeContents(seq)
-// 			  break
-// 			case Ber.CONTEXT(2):
-// 				kids = decodeChildren(seq)
-// 				break
-// 			default:
-// 				throw new Error(``)
-// 		}
-// 	}
-// 	if (number === null) {
-// 		throw new Error(``)
-// 	}
-// 	if (contents === null) {
-// 		return new TreeImpl(
-// 			new EmberNodeImpl(),
-// 			undefined,
-// 			kids)
-// 	}
-// 	return new TreeImpl(new EmberNodeImpl(
-// 			contents.identifier,
-// 			contents.description,
-// 			contents.isRoot,
-// 			contents.isOnline,
-// 			contents.schemaIdentifiers,
-// 			contents.templateReference
-// 		),
-// 		undefined,
-// 		kids)
-// }
-
-function decodeNode(reader: Ber.Reader): EmberNode {
-	const n: EmberNode = {} as EmberNode
+function decodeNode(
+	reader: Ber.Reader,
+	options: DecodeOptions = defaultDecode
+): DecodeResult<EmberNode> {
 	const ber = reader.getSequence(Ber.BERDataTypes.SET)
+	let identifier: string | undefined = undefined
+	let description: string | undefined = undefined
+	let isRoot: boolean | undefined = undefined
+	let isOnline: boolean | undefined = undefined
+	let schemaIdentifiers: string | undefined = undefined
+	let templateReference: RelativeOID | undefined = undefined
+	const errors: Array<Error> = []
 	while (ber.remain > 0) {
 		const tag = ber.peek()
 		if (tag === null) {
-			throw new Error(``)
+			unknownContext(errors, 'decode node', tag, options)
+			continue
 		}
 		const seq = ber.getSequence(tag)
 		switch (tag) {
 			case Ber.CONTEXT(0):
-				n.identifier = seq.readString(Ber.BERDataTypes.STRING)
+				identifier = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			case Ber.CONTEXT(1):
-				n.description = seq.readString(Ber.BERDataTypes.STRING)
+				description = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			case Ber.CONTEXT(2):
-				n.isRoot = seq.readBoolean()
+				isRoot = seq.readBoolean()
 				break
 			case Ber.CONTEXT(3):
-				n.isOnline = seq.readBoolean()
+				isOnline = seq.readBoolean()
 				break
 			case Ber.CONTEXT(4):
-				n.schemaIdentifiers = seq.readString(Ber.BERDataTypes.STRING)
+				schemaIdentifiers = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			case Ber.CONTEXT(5):
-				n.templateReference = seq.readRelativeOID(Ber.BERDataTypes.RELATIVE_OID)
+				templateReference = seq.readRelativeOID(Ber.BERDataTypes.RELATIVE_OID)
 				break
 			default:
-				throw new Error(``)
+				unknownContext(errors, 'deocde node', tag, options)
+				break
 		}
 	}
-	return new EmberNodeImpl(
-		n.identifier,
-		n.description,
-		n.isRoot,
-		n.isOnline,
-		n.schemaIdentifiers,
-		n.templateReference
+	return makeResult(
+		new EmberNodeImpl(
+			identifier,
+			description,
+			isRoot,
+			isOnline,
+			schemaIdentifiers,
+			templateReference
+		),
+		errors
 	)
 }

--- a/src/encodings/ber/decoder/Matrix.ts
+++ b/src/encodings/ber/decoder/Matrix.ts
@@ -11,12 +11,27 @@ import { EmberElement } from '../../../model/EmberElement'
 import { decodeChildren } from './Tree'
 import { decodeConnection } from './Connection'
 import { decodeLabel } from './Label'
-import { MatrixBERID } from '../constants'
+import { MatrixBERID, TargetBERID, SourceBERID } from '../constants'
 import { QualifiedElementImpl, NumberedTreeNodeImpl, TreeElement } from '../../../model/Tree'
+import {
+	DecodeOptions,
+	defaultDecode,
+	DecodeResult,
+	appendErrors,
+	makeResult,
+	unexpected,
+	unknownContext,
+	check
+} from './DecodeResult'
+import { Label } from '../../../model/Label'
 
 export { decodeMatrix }
 
-function decodeMatrix(reader: Ber.Reader, isQualified = false): TreeElement<Matrix> {
+function decodeMatrix(
+	reader: Ber.Reader,
+	isQualified = false,
+	options: DecodeOptions = defaultDecode
+): DecodeResult<TreeElement<Matrix>> {
 	const ber = reader.getSequence(MatrixBERID)
 	let number: number | null = null
 	let path: RelativeOID | null = null
@@ -25,10 +40,12 @@ function decodeMatrix(reader: Ber.Reader, isQualified = false): TreeElement<Matr
 	let connections: Connections | undefined = undefined
 	let contents: Matrix | null = null
 	let kids: Array<EmberTreeNode<EmberElement>> | undefined = undefined
+	const errors: Array<Error> = []
 	while (ber.remain > 0) {
 		const tag = ber.peek()
 		if (tag === null) {
-			throw new Error(``)
+			unknownContext(errors, 'decode matrix', tag, options)
+			continue
 		}
 		const seq = ber.getSequence(tag)
 		switch (tag) {
@@ -40,57 +57,37 @@ function decodeMatrix(reader: Ber.Reader, isQualified = false): TreeElement<Matr
 				}
 				break
 			case Ber.CONTEXT(1):
-				contents = decodeMatrixContents(seq)
+				contents = appendErrors(decodeMatrixContents(seq), errors)
 				break
 			case Ber.CONTEXT(2):
-				kids = decodeChildren(seq)
+				kids = appendErrors(decodeChildren(seq, options), errors)
 				break
 			case Ber.CONTEXT(3):
-				targets = decodeTargets(seq)
+				targets = appendErrors(decodeTargets(seq, options), errors)
 				break
 			case Ber.CONTEXT(4):
-				sources = decodeSources(seq)
+				sources = appendErrors(decodeSources(seq, options), errors)
 				break
 			case Ber.CONTEXT(5):
-				connections = decodeConnections(seq)
+				connections = appendErrors(decodeConnections(seq, options), errors)
 				break
 			default:
-				throw new Error(``)
+				unknownContext(errors, 'decode matrix', tag, options)
+				break
 		}
 	}
-	let m: MatrixImpl
-	if (contents === null) {
-		m = new MatrixImpl('', targets, sources, connections)
-	} else {
-		m = new MatrixImpl(
-			contents.identifier,
-			targets,
-			sources,
-			connections,
-			contents.description,
-			contents.matrixType,
-			contents.addressingMode,
-			contents.targetCount,
-			contents.sourceCount,
-			contents.maximumTotalConnects,
-			contents.maximumConnectsPerTarget,
-			contents.parametersLocation,
-			contents.gainParameterNumber,
-			contents.labels,
-			contents.schemaIdentifiers,
-			contents.templateReference
-		)
-	}
+	contents = check(contents, 'decode matrix', 'contents', new MatrixImpl(''), errors, options)
+	contents.targets = targets
+	contents.sources = sources
+	contents.connections = connections
 
 	let el: TreeElement<Matrix>
 	if (isQualified) {
-		if (path === null) throw new Error(``)
-
-		el = new QualifiedElementImpl(path, m, kids)
+		path = check(path, 'decode matrix', 'path', '', errors, options)
+		el = new QualifiedElementImpl(path, contents, kids)
 	} else {
-		if (number === null) throw new Error(``)
-
-		el = new NumberedTreeNodeImpl(number, m, kids)
+		number = check(number, 'decode matrix', 'number', -1, errors, options)
+		el = new NumberedTreeNodeImpl(number, contents, kids)
 	}
 
 	if (kids) {
@@ -99,132 +96,199 @@ function decodeMatrix(reader: Ber.Reader, isQualified = false): TreeElement<Matr
 		}
 	}
 
-	return el
+	return makeResult(el, errors)
 }
 
-function decodeMatrixContents(reader: Ber.Reader): Matrix {
-	const m: Matrix = {} as Matrix
+function decodeMatrixContents(
+	reader: Ber.Reader,
+	options: DecodeOptions = defaultDecode
+): DecodeResult<Matrix> {
 	const ber = reader.getSequence(Ber.BERDataTypes.SET)
 	let plTag: number | null
+	let identifier: string | undefined = undefined
+	let description: string | undefined = undefined
+	let matrixType: MatrixType | undefined = undefined
+	let addressingMode: MatrixAddressingMode | undefined = undefined
+	let targetCount: number | undefined = undefined
+	let sourceCount: number | undefined = undefined
+	let maximumTotalConnects: number | undefined = undefined
+	let maximumConnectsPerTarget: number | undefined = undefined
+	let parametersLocation: string | number | undefined = undefined
+	let gainParameterNumber: number | undefined = undefined
+	let labels: Array<Label> | undefined = undefined
+	let schemaIdentifiers: string | undefined = undefined
+	let templateReference: string | undefined = undefined
 	let labelSeq: Ber.Reader
+	const errors: Array<Error> = []
 	while (ber.remain > 0) {
 		const tag = ber.peek()
 		if (tag === null) {
-			throw new Error(``)
+			unknownContext(errors, 'decode matrix contents', tag, options)
+			continue
 		}
 		const seq = ber.getSequence(tag)
 		switch (tag) {
 			case Ber.CONTEXT(0):
-				m.identifier = seq.readString(Ber.BERDataTypes.STRING)
+				identifier = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			case Ber.CONTEXT(1):
-				m.description = seq.readString(Ber.BERDataTypes.STRING)
+				description = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			case Ber.CONTEXT(2):
-				m.matrixType = readMatrixType(seq.readInt())
+				matrixType = appendErrors(readMatrixType(seq.readInt(), options), errors)
 				break
 			case Ber.CONTEXT(3):
-				m.addressingMode = readAddressingMode(seq.readInt())
+				addressingMode = appendErrors(readAddressingMode(seq.readInt(), options), errors)
 				break
 			case Ber.CONTEXT(4):
-				m.targetCount = seq.readInt()
+				targetCount = seq.readInt()
 				break
 			case Ber.CONTEXT(5):
-				m.sourceCount = seq.readInt()
+				sourceCount = seq.readInt()
 				break
 			case Ber.CONTEXT(6):
-				m.maximumTotalConnects = seq.readInt()
+				maximumTotalConnects = seq.readInt()
 				break
 			case Ber.CONTEXT(7):
-				m.maximumConnectsPerTarget = seq.readInt()
+				maximumConnectsPerTarget = seq.readInt()
 				break
 			case Ber.CONTEXT(8):
 				plTag = seq.peek()
 				if (plTag === Ber.BERDataTypes.RELATIVE_OID) {
-					m.parametersLocation = seq.readRelativeOID(Ber.BERDataTypes.RELATIVE_OID)
+					parametersLocation = seq.readRelativeOID(Ber.BERDataTypes.RELATIVE_OID)
 				} else {
-					m.parametersLocation = seq.readInt()
+					parametersLocation = seq.readInt()
 				}
 				break
 			case Ber.CONTEXT(9):
-				m.gainParameterNumber = seq.readInt()
+				gainParameterNumber = seq.readInt()
 				break
 			case Ber.CONTEXT(10):
-				m.labels = []
+				labels = []
 				labelSeq = seq.getSequence(Ber.BERDataTypes.SEQUENCE)
 				while (labelSeq.remain > 0) {
 					const lvSeq = labelSeq.getSequence(Ber.CONTEXT(0))
-					m.labels.push(decodeLabel(lvSeq))
+					const lvVal = appendErrors(decodeLabel(lvSeq, options), errors)
+					labels.push(lvVal)
 				}
 				break
 			case Ber.CONTEXT(11):
-				m.schemaIdentifiers = seq.readString(Ber.BERDataTypes.STRING)
+				schemaIdentifiers = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			case Ber.CONTEXT(12):
-				m.templateReference = seq.readRelativeOID(Ber.BERDataTypes.RELATIVE_OID)
+				templateReference = seq.readRelativeOID(Ber.BERDataTypes.RELATIVE_OID)
 				break
 			default:
-				throw new Error(``)
+				unknownContext(errors, 'decode mattric contents', tag, options)
+				break
 		}
 	}
-	return m
+	identifier = check(identifier, 'decode matrix contents', 'identifier', '', errors, options)
+	return makeResult(
+		new MatrixImpl(
+			identifier,
+			undefined, // targets
+			undefined, // sources
+			undefined, // connections
+			description,
+			matrixType,
+			addressingMode,
+			targetCount,
+			sourceCount,
+			maximumTotalConnects,
+			maximumConnectsPerTarget,
+			parametersLocation,
+			gainParameterNumber,
+			labels,
+			schemaIdentifiers,
+			templateReference
+		),
+		errors
+	)
 }
 
-function decodeTargets(reader: Ber.Reader): Array<number> {
+function decodeTargets(
+	reader: Ber.Reader,
+	_options: DecodeOptions = defaultDecode
+): DecodeResult<Array<number>> {
 	const targets: Array<number> = []
 	const ber = reader.getSequence(Ber.BERDataTypes.SEQUENCE)
 	while (ber.remain > 0) {
 		const seq1 = ber.getSequence(Ber.CONTEXT(0))
-		const seq2 = seq1.getSequence(Ber.APPLICATION(14))
+		const seq2 = seq1.getSequence(TargetBERID)
 		const seq3 = seq2.getSequence(Ber.CONTEXT(0))
 		targets.push(seq3.readInt())
 	}
-	return targets
+	return makeResult(targets)
 }
 
-function decodeSources(reader: Ber.Reader): Array<number> {
+function decodeSources(
+	reader: Ber.Reader,
+	_options: DecodeOptions = defaultDecode
+): DecodeResult<Array<number>> {
 	const sources: Array<number> = []
 	const ber = reader.getSequence(Ber.BERDataTypes.SEQUENCE)
 	while (ber.remain > 0) {
 		const seq1 = ber.getSequence(Ber.CONTEXT(0))
-		const seq2 = seq1.getSequence(Ber.APPLICATION(15))
+		const seq2 = seq1.getSequence(SourceBERID)
 		const seq3 = seq2.getSequence(Ber.CONTEXT(0))
 		sources.push(seq3.readInt())
 	}
-	return sources
+	return makeResult(sources)
 }
 
-function decodeConnections(reader: Ber.Reader): Connections {
-	const connections: Connections = {}
+function decodeConnections(
+	reader: Ber.Reader,
+	options: DecodeOptions = defaultDecode
+): DecodeResult<Connections> {
+	const connections = makeResult<Connections>({})
 	const seq = reader.getSequence(Ber.BERDataTypes.SEQUENCE)
 	while (seq.remain > 0) {
 		const conSeq = seq.getSequence(Ber.CONTEXT(0))
-		const connection = decodeConnection(conSeq)
-		connections[connection.target] = connection
+		const connection = appendErrors(decodeConnection(conSeq, options), connections)
+		connections.value[connection.target] = connection
 	}
 	return connections
 }
 
-function readMatrixType(value: number): MatrixType {
+function readMatrixType(
+	value: number,
+	options: DecodeOptions = defaultDecode
+): DecodeResult<MatrixType> {
 	switch (value) {
 		case 0:
-			return MatrixType.OneToN
+			return makeResult(MatrixType.OneToN)
 		case 1:
-			return MatrixType.OneToOne
+			return makeResult(MatrixType.OneToOne)
 		case 2:
-			return MatrixType.NToN
+			return makeResult(MatrixType.NToN)
 		default:
-			throw new Error(``)
+			return unexpected(
+				[],
+				'read matrix type',
+				`unexpected matrix type '${value}'`,
+				MatrixType.NToN,
+				options
+			)
 	}
 }
 
-function readAddressingMode(value: number): MatrixAddressingMode {
+function readAddressingMode(
+	value: number,
+	options: DecodeOptions = defaultDecode
+): DecodeResult<MatrixAddressingMode> {
 	switch (value) {
 		case 0:
-			return MatrixAddressingMode.Linear
+			return makeResult(MatrixAddressingMode.Linear)
 		case 1:
-			return MatrixAddressingMode.NonLinear
+			return makeResult(MatrixAddressingMode.NonLinear)
 		default:
-			throw new Error(``)
+			return unexpected(
+				[],
+				'read addressing mode',
+				`unexpected addressing mode '${value}'`,
+				MatrixAddressingMode.Linear,
+				options
+			)
 	}
 }

--- a/src/encodings/ber/decoder/Parameter.ts
+++ b/src/encodings/ber/decoder/Parameter.ts
@@ -9,7 +9,8 @@ import {
 	check,
 	makeResult,
 	unexpected,
-	appendErrors
+	appendErrors,
+	unknownContext
 } from './DecodeResult'
 import { EmberValue, StringIntegerCollection, RelativeOID } from '../../../types/types'
 import { StreamDescription } from '../../../model/StreamDescription'
@@ -47,7 +48,8 @@ function decodeParameter(
 	while (ber.remain > 0) {
 		const tag = ber.peek()
 		if (tag === null) {
-			throw new Error(``)
+			unknownContext(errors, 'decode parameter', tag, options)
+			continue
 		}
 		const seq = ber.getSequence(tag)
 		switch (tag) {
@@ -109,7 +111,8 @@ function decodeParameter(
 				templateReference = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			default:
-				throw new Error(``)
+				unknownContext(errors, 'decode parameter', tag, options)
+				break
 		}
 	}
 	parameterType = check(

--- a/src/encodings/ber/decoder/Parameter.ts
+++ b/src/encodings/ber/decoder/Parameter.ts
@@ -1,46 +1,48 @@
 import * as Ber from '../../../Ber'
 import { Parameter, ParameterType, ParameterImpl, ParameterAccess } from '../../../model/Parameter'
-// import { TreeImpl } from '../../../model/Tree'
-// import { EmberTreeNode } from '../../../types/types'
-// import { EmberElement } from '../../../model/EmberElement'
 import { decodeStreamDescription } from './StreamDescription'
-// import { decodeChildren } from './Tree';
-// import { ParameterBERID } from '../constants';
 import { decodeStringIntegerCollection } from './StringIntegerCollection'
+import {
+	DecodeOptions,
+	defaultDecode,
+	DecodeResult,
+	check,
+	makeResult,
+	unexpected,
+	appendErrors
+} from './DecodeResult'
+import { EmberValue, StringIntegerCollection, RelativeOID } from '../../../types/types'
+import { StreamDescription } from '../../../model/StreamDescription'
 
 export { decodeParameter, readParameterType }
 
-// function decodeParameter (reader: Ber.Reader): EmberTreeNode<Parameter> {
-// 	const ber = reader.getSequence(ParameterBERID)
-// 	//let _num: number | undefined = undefined
-// 	let param: Parameter | undefined = undefined
-// 	let kids: Array<EmberTreeNode<EmberElement>> = []
-// 	while (ber.remain > 0) {
-// 		const tag = ber.peek()
-// 		const seq = ber.getSequence(tag!)
-
-// 		switch (tag) {
-// 			case Ber.CONTEXT(0):
-// 				//_num = seq.readInt()
-// 				break
-// 			case Ber.CONTEXT(1):
-// 				param = decodeParameterContents(seq)
-// 				break
-// 			case Ber.CONTEXT(2):
-// 				kids = decodeChildren(seq)
-// 				break
-// 		}
-// 	}
-// 	if (!param) {
-// 		throw new Error('Decode parameter: failed to decode parameter')
-// 	}
-// 	// param.number = typeof num === 'number' ? num : -1
-// 	return new TreeImpl(param, undefined, kids)
-// }
-
-function decodeParameter(reader: Ber.Reader): Parameter {
+function decodeParameter(
+	reader: Ber.Reader,
+	options: DecodeOptions = defaultDecode
+): DecodeResult<Parameter> {
 	const ber = reader.getSequence(Ber.BERDataTypes.SET)
-	const p: Parameter = {} as Parameter
+
+	let identifier: string | undefined = undefined
+	let description: string | undefined = undefined
+	let value: EmberValue | undefined = undefined
+	let minimum: number | null | undefined = undefined
+	let maximum: number | null | undefined = undefined
+	let access: ParameterAccess | undefined = undefined
+	let format: string | undefined = undefined
+	let enumeration: string | undefined = undefined
+	let factor: number | undefined = undefined
+	let isOnline: boolean | undefined = undefined
+	let formula: string | undefined = undefined
+	let step: number | undefined = undefined
+	let defaultValue: EmberValue | undefined = undefined
+	let parameterType: ParameterType | undefined = undefined
+	let streamIdentifier: number | undefined = undefined
+	let enumMap: StringIntegerCollection | undefined = undefined
+	let streamDescriptor: StreamDescription | undefined = undefined
+	let schemaIdentifiers: string | undefined = undefined
+	let templateReference: RelativeOID | undefined = undefined
+
+	const errors: Array<Error> = []
 
 	while (ber.remain > 0) {
 		const tag = ber.peek()
@@ -50,124 +52,147 @@ function decodeParameter(reader: Ber.Reader): Parameter {
 		const seq = ber.getSequence(tag)
 		switch (tag) {
 			case Ber.CONTEXT(0):
-				p.identifier = seq.readString(Ber.BERDataTypes.STRING)
+				identifier = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			case Ber.CONTEXT(1):
-				p.description = seq.readString(Ber.BERDataTypes.STRING)
+				description = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			case Ber.CONTEXT(2):
-				p.value = seq.readValue().value
+				value = seq.readValue().value
 				break
 			case Ber.CONTEXT(3):
-				p.minimum = seq.readValue().value as number | null
+				minimum = seq.readValue().value as number | null
 				break
 			case Ber.CONTEXT(4):
-				p.maximum = seq.readValue().value as number | null
+				maximum = seq.readValue().value as number | null
 				break
 			case Ber.CONTEXT(5):
-				p.access = readParameterAccess(seq.readInt())
+				access = appendErrors(readParameterAccess(seq.readInt(), options), errors)
 				break
 			case Ber.CONTEXT(6):
-				p.format = seq.readString(Ber.BERDataTypes.STRING)
+				format = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			case Ber.CONTEXT(7):
-				p.enumeration = seq.readString(Ber.BERDataTypes.STRING)
+				enumeration = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			case Ber.CONTEXT(8):
-				p.factor = seq.readInt()
+				factor = seq.readInt()
 				break
 			case Ber.CONTEXT(9):
-				p.isOnline = seq.readBoolean()
+				isOnline = seq.readBoolean()
 				break
 			case Ber.CONTEXT(10):
-				p.formula = seq.readString(Ber.BERDataTypes.STRING)
+				formula = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			case Ber.CONTEXT(11):
-				p.step = seq.readInt()
+				step = seq.readInt()
 				break
 			case Ber.CONTEXT(12):
-				p.defaultValue = seq.readValue().value // Write value uses type
+				defaultValue = seq.readValue().value // Write value uses type
 				break
 			case Ber.CONTEXT(13):
-				p.parameterType = readParameterType(seq.readInt())
+				parameterType = appendErrors(readParameterType(seq.readInt(), options), errors)
 				break
 			case Ber.CONTEXT(14):
-				p.streamIdentifier = seq.readInt()
+				streamIdentifier = seq.readInt()
 				break
 			case Ber.CONTEXT(15):
-				p.enumMap = decodeStringIntegerCollection(seq)
+				enumMap = appendErrors(decodeStringIntegerCollection(seq, options), errors)
 				break
 			case Ber.CONTEXT(16):
-				p.streamDescriptor = decodeStreamDescription(seq)
+				streamDescriptor = appendErrors(decodeStreamDescription(seq, options), errors)
 				break
 			case Ber.CONTEXT(17):
-				p.schemaIdentifiers = seq.readString(Ber.BERDataTypes.STRING)
+				schemaIdentifiers = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			case Ber.CONTEXT(18):
-				p.templateReference = seq.readString(Ber.BERDataTypes.STRING)
+				templateReference = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			default:
 				throw new Error(``)
 		}
 	}
+	parameterType = check(
+		parameterType,
+		'decode parameter',
+		'parameterType',
+		ParameterType.Null,
+		errors,
+		options
+	)
 
-	return new ParameterImpl(
-		p.parameterType,
-		p.identifier,
-		p.description,
-		p.value,
-		p.maximum,
-		p.minimum,
-		p.access,
-		p.format,
-		p.enumeration,
-		p.factor,
-		p.isOnline,
-		p.formula,
-		p.step,
-		p.defaultValue,
-		p.streamIdentifier,
-		p.enumMap,
-		p.streamDescriptor,
-		p.schemaIdentifiers,
-		p.templateReference
+	return makeResult(
+		new ParameterImpl(
+			parameterType,
+			identifier,
+			description,
+			value,
+			maximum,
+			minimum,
+			access,
+			format,
+			enumeration,
+			factor,
+			isOnline,
+			formula,
+			step,
+			defaultValue,
+			streamIdentifier,
+			enumMap,
+			streamDescriptor,
+			schemaIdentifiers,
+			templateReference
+		),
+		errors
 	)
 }
 
-function readParameterAccess(value: number): ParameterAccess {
+function readParameterAccess(value: number, options: DecodeOptions): DecodeResult<ParameterAccess> {
 	switch (value) {
 		case 0:
-			return ParameterAccess.None
+			return makeResult(ParameterAccess.None)
 		case 1:
-			return ParameterAccess.Read
+			return makeResult(ParameterAccess.Read)
 		case 2:
-			return ParameterAccess.Write
+			return makeResult(ParameterAccess.Write)
 		case 3:
-			return ParameterAccess.ReadWrite
+			return makeResult(ParameterAccess.ReadWrite)
 		default:
-			throw new Error(``)
+			return unexpected(
+				[],
+				'read parameter access',
+				`unexpected parameter access '${value}'`,
+				ParameterAccess.ReadWrite,
+				options
+			)
 	}
 }
 
-function readParameterType(value: number): ParameterType {
+function readParameterType(value: number, options: DecodeOptions): DecodeResult<ParameterType> {
 	switch (value) {
 		case 0:
-			return ParameterType.Null
+			return makeResult(ParameterType.Null)
 		case 1:
-			return ParameterType.Integer
+			return makeResult(ParameterType.Integer)
 		case 2:
-			return ParameterType.Real
+			return makeResult(ParameterType.Real)
 		case 3:
-			return ParameterType.String
+			return makeResult(ParameterType.String)
 		case 4:
-			return ParameterType.Boolean
+			return makeResult(ParameterType.Boolean)
 		case 5:
-			return ParameterType.Trigger
+			return makeResult(ParameterType.Trigger)
 		case 6:
-			return ParameterType.Enum
+			return makeResult(ParameterType.Enum)
 		case 7:
-			return ParameterType.Octets
+			return makeResult(ParameterType.Octets)
 		default:
-			throw new Error(``)
+			return unexpected(
+				[],
+				'read parameter type',
+				`unexpected parameter type '${value}'`,
+				ParameterType.Null,
+				options
+			)
 	}
 }

--- a/src/encodings/ber/decoder/StreamDescription.ts
+++ b/src/encodings/ber/decoder/StreamDescription.ts
@@ -5,73 +5,97 @@ import {
 	StreamFormat
 } from '../../../model/StreamDescription'
 import { StreamDescriptionBERID } from '../constants'
+import {
+	DecodeOptions,
+	defaultDecode,
+	DecodeResult,
+	unknownContext,
+	check,
+	appendErrors,
+	makeResult,
+	unexpected
+} from './DecodeResult'
 
-export function decodeStreamDescription(reader: Ber.Reader): StreamDescription {
+export function decodeStreamDescription(
+	reader: Ber.Reader,
+	options: DecodeOptions = defaultDecode
+): DecodeResult<StreamDescription> {
 	const ber = reader.getSequence(StreamDescriptionBERID)
 	let format: StreamFormat | null = null
 	let offset: number | null = null
+	const errors: Array<Error> = []
 	while (ber.remain > 0) {
 		const tag = ber.peek()
 		if (tag === null) {
-			throw new Error(``)
+			unknownContext(errors, 'decode stream description', tag, options)
+			continue
 		}
 		const seq = ber.getSequence(tag)
 		switch (tag) {
 			case Ber.CONTEXT(0):
-				format = readStreamFormat(seq.readInt())
+				format = appendErrors(readStreamFormat(seq.readInt(), options), errors)
 				break
 			case Ber.CONTEXT(1):
 				offset = seq.readInt()
 				break
 			default:
-				throw new Error(``)
+				unknownContext(errors, 'decode stream description', tag, options)
+				break
 		}
 	}
-	if (format === null || offset === null) {
-		throw new Error(``)
-	}
-	return new StreamDescriptionImpl(format, offset)
+	format = check(format, 'decode stream description', 'format', StreamFormat.UInt8, errors, options)
+	offset = check(offset, 'decode stream description', 'offset', 0, errors, options)
+	return makeResult(new StreamDescriptionImpl(format, offset), errors)
 }
 
-function readStreamFormat(value: number): StreamFormat {
+function readStreamFormat(
+	value: number,
+	options: DecodeOptions = defaultDecode
+): DecodeResult<StreamFormat> {
 	switch (value) {
 		case 0:
-			return StreamFormat.UInt8
+			return makeResult(StreamFormat.UInt8)
 		case 2:
-			return StreamFormat.UInt16BE
+			return makeResult(StreamFormat.UInt16BE)
 		case 3:
-			return StreamFormat.UInt16LE
+			return makeResult(StreamFormat.UInt16LE)
 		case 4:
-			return StreamFormat.UInt32BE
+			return makeResult(StreamFormat.UInt32BE)
 		case 5:
-			return StreamFormat.UInt32LE
+			return makeResult(StreamFormat.UInt32LE)
 		case 6:
-			return StreamFormat.UInt64BE
+			return makeResult(StreamFormat.UInt64BE)
 		case 7:
-			return StreamFormat.UInt64LE
+			return makeResult(StreamFormat.UInt64LE)
 		case 8:
-			return StreamFormat.Int8
+			return makeResult(StreamFormat.Int8)
 		case 10:
-			return StreamFormat.Int16BE
+			return makeResult(StreamFormat.Int16BE)
 		case 11:
-			return StreamFormat.Int16LE
+			return makeResult(StreamFormat.Int16LE)
 		case 12:
-			return StreamFormat.Int32BE
+			return makeResult(StreamFormat.Int32BE)
 		case 13:
-			return StreamFormat.Int32LE
+			return makeResult(StreamFormat.Int32LE)
 		case 14:
-			return StreamFormat.Int64BE
+			return makeResult(StreamFormat.Int64BE)
 		case 15:
-			return StreamFormat.Int64LE
+			return makeResult(StreamFormat.Int64LE)
 		case 20:
-			return StreamFormat.Float32BE
+			return makeResult(StreamFormat.Float32BE)
 		case 21:
-			return StreamFormat.Float32LE
+			return makeResult(StreamFormat.Float32LE)
 		case 22:
-			return StreamFormat.Float64BE
+			return makeResult(StreamFormat.Float64BE)
 		case 23:
-			return StreamFormat.Float64LE
+			return makeResult(StreamFormat.Float64LE)
 		default:
-			throw new Error(``)
+			return unexpected(
+				[],
+				'read stream format',
+				`unexpected stream format '${value}'`,
+				StreamFormat.UInt8,
+				options
+			)
 	}
 }

--- a/src/encodings/ber/decoder/StringIntegerCollection.ts
+++ b/src/encodings/ber/decoder/StringIntegerCollection.ts
@@ -1,32 +1,51 @@
 import * as Ber from '../../../Ber'
 import { StringIntegerCollection } from '../../../types/types'
 import { StringIntegerCollectionBERID, StringIntegerPairBERID } from '../constants'
+import {
+	DecodeOptions,
+	defaultDecode,
+	DecodeResult,
+	makeResult,
+	unknownContext,
+	appendErrors,
+	check
+} from './DecodeResult'
 
 export { decodeStringIntegerCollection }
 
-function decodeStringIntegerCollection(reader: Ber.Reader): StringIntegerCollection {
+function decodeStringIntegerCollection(
+	reader: Ber.Reader,
+	options: DecodeOptions = defaultDecode
+): DecodeResult<StringIntegerCollection> {
 	const seq = reader.getSequence(StringIntegerCollectionBERID)
 	const collection: StringIntegerCollection = new Map<string, number>()
+	const errors: Array<Error> = []
 	while (seq.remain > 0) {
 		const tag = seq.peek()
 		if (tag !== Ber.CONTEXT(0)) {
-			throw new Error(``)
+			unknownContext(errors, 'decode string integer collection', tag, options)
+			continue
 		}
 		const data = seq.getSequence(Ber.CONTEXT(0))
-		const pair = decodeStringIntegerPair(data)
+		const pair = appendErrors(decodeStringIntegerPair(data, options), errors)
 		collection.set(pair.key, pair.value)
 	}
-	return collection
+	return makeResult(collection, errors)
 }
 
-function decodeStringIntegerPair(reader: Ber.Reader): { key: string; value: number } {
+function decodeStringIntegerPair(
+	reader: Ber.Reader,
+	options: DecodeOptions = defaultDecode
+): DecodeResult<{ key: string; value: number }> {
 	let key: string | null = null
 	let value: number | null = null
+	const errors: Array<Error> = []
 	const seq = reader.getSequence(StringIntegerPairBERID)
 	while (seq.remain > 0) {
 		const tag = seq.peek()
 		if (tag === null) {
-			throw new Error(``)
+			unknownContext(errors, 'decode string integer pair', tag, options)
+			continue
 		}
 		const dataSeq = seq.getSequence(tag)
 		switch (tag) {
@@ -37,11 +56,18 @@ function decodeStringIntegerPair(reader: Ber.Reader): { key: string; value: numb
 				value = dataSeq.readInt()
 				break
 			default:
-				throw new Error(``)
+				unknownContext(errors, 'deocde string integer pair', tag, options)
+				break
 		}
 	}
-	if (key === null || value === null) {
-		throw new Error(``)
-	}
-	return { key, value }
+	key = check(
+		key,
+		'decode string integer pair',
+		'key',
+		`key${(Math.random() * 1000000) | 0}`,
+		errors,
+		options
+	)
+	value = check(value, 'decode string integer pair', 'value', -1, errors, options)
+	return makeResult({ key, value }, errors)
 }

--- a/src/encodings/ber/decoder/Template.ts
+++ b/src/encodings/ber/decoder/Template.ts
@@ -8,45 +8,69 @@ import { EmberTreeNode, TreeElement } from '../../../types/types'
 import { TemplateBERID, QualifiedTemplateBERID } from '../constants'
 import { decodeGenericElement } from './Tree'
 import { NumberedTreeNodeImpl, QualifiedElementImpl } from '../../../model/Tree'
+import {
+	DecodeOptions,
+	defaultDecode,
+	DecodeResult,
+	unknownContext,
+	appendErrors,
+	check,
+	makeResult
+} from './DecodeResult'
 
-export function decodeTemplate(reader: Ber.Reader, isQualified = false): TreeElement<Template> {
+export function decodeTemplate(
+	reader: Ber.Reader,
+	isQualified = false,
+	options: DecodeOptions = defaultDecode
+): DecodeResult<TreeElement<Template>> {
 	const ber = reader.getSequence(isQualified ? QualifiedTemplateBERID : TemplateBERID)
 	let number: number | null = null
 	let path: string | null = null
 	let element: EmberTreeNode<Parameter | EmberNode | Matrix | EmberFunction> | undefined = undefined
 	let description: string | undefined = undefined
+	const errors: Array<Error> = []
 	while (ber.remain > 0) {
 		const tag = ber.peek()
 		if (tag === null) {
-			throw new Error(``)
+			unknownContext(errors, 'decode tempalte', tag, options)
+			continue
 		}
 		const seq = ber.getSequence(tag)
 		switch (tag) {
 			case Ber.CONTEXT(0):
-				if (isQualified) path = seq.readRelativeOID()
-				else number = seq.readInt()
+				if (isQualified) {
+					path = seq.readRelativeOID()
+				} else {
+					number = seq.readInt()
+				}
 				break
 			case Ber.CONTEXT(1):
-				element = decodeGenericElement(seq) as EmberTreeNode<
-					Parameter | EmberNode | Matrix | EmberFunction
-				>
+				element = appendErrors(
+					decodeGenericElement(seq, options) as DecodeResult<
+						EmberTreeNode<Parameter | EmberNode | Matrix | EmberFunction>
+					>,
+					errors
+				)
 				break
 			case Ber.CONTEXT(2):
 				description = seq.readString(Ber.BERDataTypes.STRING)
 				break
 			default:
-				throw new Error(``)
+				unknownContext(errors, 'decode template', tag, options)
+				break
 		}
 	}
 	if (isQualified) {
-		if (path === null) {
-			throw new Error(``)
-		}
-		return new QualifiedElementImpl(path, new TemplateImpl(element, description))
+		path = check(path, 'decode template', 'path', '', errors, options)
+		return makeResult(
+			new QualifiedElementImpl(path, new TemplateImpl(element, description)),
+			errors
+		)
 	} else {
-		if (number === null) {
-			throw new Error(``)
-		}
-		return new NumberedTreeNodeImpl(number, new TemplateImpl(element, description))
+		number = check(number, 'decode tempalte', 'number', -1, errors, options)
+		return makeResult(
+			new NumberedTreeNodeImpl(number, new TemplateImpl(element, description)),
+			errors
+		)
 	}
 }

--- a/src/encodings/ber/index.ts
+++ b/src/encodings/ber/index.ts
@@ -86,6 +86,6 @@ function berDecode(b: Buffer, options: DecodeOptions = defaultDecode): DecodeRes
 		return root
 	}
 
-	unknownApplication(errors, 'decode root', tag, options)
+	unknownApplication(errors, 'decode root', rootSeqType, options)
 	return makeResult([new NumberedTreeNodeImpl(-1, new EmberNodeImpl())], errors)
 }

--- a/src/model/Template.ts
+++ b/src/model/Template.ts
@@ -22,7 +22,6 @@ interface Template extends EmberElement {
 class TemplateImpl implements Template {
 	public readonly type: ElementType.Template = ElementType.Template
 	constructor(
-		public number: number,
 		public element?: NumberedTreeNode<Parameter | EmberNode | Matrix | EmberFunction>,
 		public description?: string
 	) {}


### PR DESCRIPTION
The forgiving decoder allows streams with issues to be decoded to a tree even with missing data or unknown tags. Options allow control over whether certain issues allow the decode to proceed or stop the decode by throwing.