### PR TITLE
fix: convert tree arrays into collections

### DIFF
--- a/src/encodings/ber/__tests__/index.spec.ts
+++ b/src/encodings/ber/__tests__/index.spec.ts
@@ -1,6 +1,6 @@
 import { InvocationResultImpl } from '../../../model/InvocationResult'
 import { ParameterType } from '../../../model/Parameter'
-import { Root, RootType, RootElement } from '../../../types/types'
+import { Root, RootType, RootElement, Collection } from '../../../types/types'
 import { berEncode, berDecode } from '..'
 import { QualifiedElementImpl, NumberedTreeNodeImpl } from '../../../model/Tree'
 import { EmberNodeImpl } from '../../../model/EmberNode'
@@ -22,19 +22,19 @@ describe('encoders/Ber/index', () => {
 		roundTrip(res, RootType.InvocationResult)
 	})
 	test('Qualified node', () => {
-		const res = [new QualifiedElementImpl('2.3.1', new EmberNodeImpl('Test node'))]
+		const res = { 0: new QualifiedElementImpl('2.3.1', new EmberNodeImpl('Test node')) }
 		roundTrip(res, RootType.Elements)
 	})
 	test('Numbered node', () => {
-		const res = [new NumberedTreeNodeImpl(0, new EmberNodeImpl('Test node'))]
+		const res = { 0: new NumberedTreeNodeImpl(0, new EmberNodeImpl('Test node')) }
 		roundTrip(res, RootType.Elements)
 	})
 	test('Numbered tree', () => {
-		const res = [
-			new NumberedTreeNodeImpl(0, new EmberNodeImpl('Test node'), [
-				new NumberedTreeNodeImpl(0, new EmberNodeImpl('Test node 1'))
-			])
-		]
+		const res = {
+			0: new NumberedTreeNodeImpl(0, new EmberNodeImpl('Test node'), {
+				0: new NumberedTreeNodeImpl(0, new EmberNodeImpl('Test node 1'))
+			})
+		}
 		if (!res[0].children) {
 			fail(`Tree must have children`)
 		}
@@ -42,11 +42,11 @@ describe('encoders/Ber/index', () => {
 		roundTrip(res, RootType.Elements)
 	})
 	test('Qualified tree', () => {
-		const res = [
-			new QualifiedElementImpl('2.3.1', new EmberNodeImpl('Test node'), [
-				new NumberedTreeNodeImpl(0, new EmberNodeImpl('Node A'), [])
-			])
-		]
+		const res = {
+			0: new QualifiedElementImpl('2.3.1', new EmberNodeImpl('Test node'), {
+				0: new NumberedTreeNodeImpl(0, new EmberNodeImpl('Node A'), {})
+			})
+		}
 		if (!res[0].children) {
 			fail(`Tree must have children`)
 		}
@@ -58,7 +58,7 @@ describe('encoders/Ber/index', () => {
 		const decoded = berDecode(testBuffer)
 
 		expect(decoded.value).toHaveLength(1)
-		expect((decoded.value as RootElement[])[0].contents.type).toBe(ElementType.Node)
+		expect((decoded.value as Collection<RootElement>)[0].contents.type).toBe(ElementType.Node)
 		expect(decoded.errors).toHaveLength(1)
 		expect(decoded.errors?.toString()).toMatch(/Unexpected BER application tag '126'/)
 	})
@@ -67,7 +67,7 @@ describe('encoders/Ber/index', () => {
 		const decoded = berDecode(testBuffer)
 
 		expect(decoded.value).toHaveLength(1)
-		expect((decoded.value as RootElement[])[0].contents.type).toBe(ElementType.Node)
+		expect((decoded.value as Collection<RootElement>)[0].contents.type).toBe(ElementType.Node)
 		expect(decoded.errors).toHaveLength(1)
 		expect(decoded.errors?.toString()).toMatch(/Unexpected BER application tag '127'/)
 	})

--- a/src/encodings/ber/encoder/Tree.ts
+++ b/src/encodings/ber/encoder/Tree.ts
@@ -71,7 +71,7 @@ export function encodeTree(el: TreeElement<EmberElement>, writer: Ber.Writer): v
 		writer.startSequence(Ber.CONTEXT(2)) // start children
 		writer.startSequence(ElementCollectionBERID) // start ElementCollection
 		if (el.children) {
-			for (const child of el.children) {
+			for (const child of Object.values(el.children)) {
 				writer.startSequence(Ber.CONTEXT(0)) // start child
 				encodeNumberedElement(child, writer)
 				writer.endSequence() // end child

--- a/src/encodings/ber/index.ts
+++ b/src/encodings/ber/index.ts
@@ -1,4 +1,4 @@
-import { Root, RootType, RootElement } from '../../types/types'
+import { Root, RootType, RootElement, Collection } from '../../types/types'
 import * as Ber from '../../Ber'
 import { encodeInvocationResult } from './encoder/InvocationResult'
 import { InvocationResult } from '../../model/InvocationResult'
@@ -33,7 +33,7 @@ function berEncode(el: Root, rootType: RootType): Buffer {
 	switch (rootType) {
 		case RootType.Elements:
 			writer.startSequence(RootElementsBERID) // Start RootElementCollection
-			for (const rootEl of el as RootElement[]) {
+			for (const rootEl of Object.values(el as Collection<RootElement>)) {
 				writer.startSequence(Ber.CONTEXT(0))
 				encodeRootElement(rootEl, writer)
 				writer.endSequence()
@@ -42,7 +42,7 @@ function berEncode(el: Root, rootType: RootType): Buffer {
 			break
 		case RootType.Streams:
 			writer.startSequence(StreamEntriesBERID) // Start StreamCollection
-			for (const entry of el as StreamEntry[]) {
+			for (const entry of Object.values(el as Collection<StreamEntry>)) {
 				writer.startSequence(Ber.CONTEXT(0))
 				encodeStreamEntry(entry, writer)
 				writer.endSequence()
@@ -74,11 +74,11 @@ function berDecode(b: Buffer, options: DecodeOptions = defaultDecode): DecodeRes
 
 	if (rootSeqType === RootElementsBERID) {
 		// RootElementCollection
-		const root: DecodeResult<Array<RootElement>> = decodeRootElements(rootSeq, options)
+		const root: DecodeResult<Collection<RootElement>> = decodeRootElements(rootSeq, options)
 		return root
 	} else if (rootSeqType === StreamEntriesBERID) {
 		// StreamCollection
-		const root: DecodeResult<Array<StreamEntry>> = decodeStreamEntries(rootSeq, options)
+		const root: DecodeResult<Collection<StreamEntry>> = decodeStreamEntries(rootSeq, options)
 		return root
 	} else if (rootSeqType === InvocationResultBERID) {
 		// InvocationResult

--- a/src/model/Tree.ts
+++ b/src/model/Tree.ts
@@ -1,5 +1,5 @@
 import { EmberElement } from './EmberElement'
-import { RelativeOID } from '../types/types'
+import { RelativeOID, RootElement, Collection } from '../types/types'
 
 export {
 	TreeElement,
@@ -10,9 +10,9 @@ export {
 }
 
 interface TreeElement<T extends EmberElement> {
-	parent?: TreeElement<EmberElement>
+	parent?: RootElement
 	contents: T
-	children?: Array<NumberedTreeNode<EmberElement>>
+	children?: Collection<NumberedTreeNode<EmberElement>>
 }
 
 interface NumberedTreeNode<T extends EmberElement> extends TreeElement<T> {
@@ -21,13 +21,14 @@ interface NumberedTreeNode<T extends EmberElement> extends TreeElement<T> {
 
 interface QualifiedElement<T extends EmberElement> extends TreeElement<T> {
 	path: RelativeOID
+	parent: undefined
 }
 
 abstract class TreeElementImpl<T extends EmberElement> implements TreeElement<T> {
 	constructor(
 		public contents: T,
-		public children?: Array<NumberedTreeNode<EmberElement>>,
-		public parent?: TreeElement<EmberElement>
+		public children?: Collection<NumberedTreeNode<EmberElement>>,
+		public parent?: RootElement
 	) {}
 }
 
@@ -36,8 +37,8 @@ class NumberedTreeNodeImpl<T extends EmberElement> extends TreeElementImpl<T>
 	constructor(
 		public number: number,
 		contents: T,
-		children?: Array<NumberedTreeNode<EmberElement>>,
-		parent?: TreeElement<EmberElement>
+		children?: Collection<NumberedTreeNode<EmberElement>>,
+		parent?: RootElement
 	) {
 		super(contents, children, parent)
 	}
@@ -45,12 +46,13 @@ class NumberedTreeNodeImpl<T extends EmberElement> extends TreeElementImpl<T>
 
 class QualifiedElementImpl<T extends EmberElement> extends TreeElementImpl<T>
 	implements QualifiedElement<T> {
+	parent = undefined
+
 	constructor(
 		public path: RelativeOID,
 		contents: T,
-		children?: Array<NumberedTreeNode<EmberElement>>,
-		parent?: TreeElement<EmberElement>
+		children?: Collection<NumberedTreeNode<EmberElement>>
 	) {
-		super(contents, children, parent)
+		super(contents, children)
 	}
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -21,7 +21,8 @@ export {
 	StringIntegerCollection,
 	RootType,
 	RelativeOID,
-	literal
+	literal,
+	Collection
 }
 
 type EmberTreeNode<T extends EmberElement> = NumberedTreeNode<T>
@@ -32,7 +33,7 @@ type RootElement =
 	| QualifiedElement<Matrix>
 	| QualifiedElement<EmberFunction>
 	| QualifiedElement<Template>
-type Root = Array<RootElement> | Array<StreamEntry> | InvocationResult
+type Root = Collection<RootElement> | Collection<StreamEntry> | InvocationResult
 
 enum RootType {
 	Elements,
@@ -54,3 +55,5 @@ type RelativeOID = string
 function literal<T>(arg: T): T {
 	return arg
 }
+
+type Collection<T> = { [index: number]: T }


### PR DESCRIPTION
Sometimes the "number" can be very high (close to maxint) which caused us to create a sparse array, by converting to objects performance should be better.