### PR TITLE
feat: remove creation of a new reader for each sequence tag

### DIFF
--- a/src/Ber/Reader.ts
+++ b/src/Ber/Reader.ts
@@ -13,10 +13,11 @@ class ExtendedReader extends Reader {
 		super(data)
 	}
 
-	getSequence(tag: number): ExtendedReader {
-		const buf = this.readString(tag, true)
-		return new ExtendedReader(buf)
-	}
+	// This is bad. No need to create a new reader for every tag!
+	// getSequence(tag: number): ExtendedReader {
+	// 	const buf = this.readString(tag, true)
+	// 	return new ExtendedReader(buf)
+	// }
 
 	readValue(): EmberTypedValue {
 		const tag = this.peek()

--- a/src/encodings/ber/decoder/DecodeResult.ts
+++ b/src/encodings/ber/decoder/DecodeResult.ts
@@ -1,4 +1,5 @@
 import { literal } from '../../../types/types'
+import * as Ber from '../../../Ber'
 
 export {
 	DecodeOptions,
@@ -13,7 +14,8 @@ export {
 	safeSet,
 	guarded,
 	appendErrors,
-	unexpected
+	unexpected,
+	skipNext
 }
 
 /**
@@ -268,5 +270,16 @@ function unexpected<T>(
 		}
 	} else {
 		throw err
+	}
+}
+
+/**
+ * Skip over a single value in the stream when it is not recognized.
+ * @param reader Reader to skip over the next tag for.
+ */
+function skipNext(reader: Ber.Reader): void {
+	const skipTag = reader.peek()
+	if (skipTag) {
+		reader.readString(skipTag, true)
 	}
 }

--- a/src/encodings/ber/decoder/Template.ts
+++ b/src/encodings/ber/decoder/Template.ts
@@ -15,7 +15,8 @@ import {
 	unknownContext,
 	appendErrors,
 	check,
-	makeResult
+	makeResult,
+	skipNext
 } from './DecodeResult'
 
 export function decodeTemplate(
@@ -53,6 +54,7 @@ export function decodeTemplate(
 				break
 			default:
 				unknownContext(errors, 'decode template', tag, options)
+				skipNext(reader)
 				break
 		}
 	}

--- a/src/encodings/ber/decoder/Tree.ts
+++ b/src/encodings/ber/decoder/Tree.ts
@@ -210,6 +210,7 @@ export function decodeRootElements(
 		if (tag !== Ber.CONTEXT(0)) {
 			unknownContext(rootEls, 'decode root elements', tag, options)
 			skipNext(reader)
+			continue
 		}
 		const rootEl = decodeGenericElement(reader, options) as DecodeResult<
 			NumberedTreeNode<EmberElement>

--- a/src/encodings/ber/decoder/Tree.ts
+++ b/src/encodings/ber/decoder/Tree.ts
@@ -38,7 +38,8 @@ import {
 	appendErrors,
 	unknownApplication,
 	check,
-	unexpected
+	unexpected,
+	skipNext
 } from './DecodeResult'
 import { Command } from '../../../model/Command'
 import { EmberNodeImpl } from '../../../model/EmberNode'
@@ -47,20 +48,17 @@ export function decodeChildren(
 	reader: Ber.Reader,
 	options: DecodeOptions = defaultDecode
 ): DecodeResult<Array<NumberedTreeNode<EmberElement>>> {
-	const ber = reader.getSequence(ElementCollectionBERID)
+	reader.readSequence(ElementCollectionBERID)
 	const kids = makeResult<Array<NumberedTreeNode<EmberElement>>>(
 		[] as Array<NumberedTreeNode<EmberElement>>
 	)
 
-	while (ber.remain > 0) {
-		const tag = ber.peek()
-
-		if (tag !== Ber.CONTEXT(0)) {
-			unknownContext(kids, 'decode children', tag, options)
-			continue
-		}
-		const seq = ber.getSequence(tag)
-		const kidEl = decodeGenericElement(seq, options) as DecodeResult<NumberedTreeNode<EmberElement>>
+	const endOffset = reader.offset + reader.length
+	while (reader.offset < endOffset) {
+		reader.readSequence()
+		const kidEl = decodeGenericElement(reader, options) as DecodeResult<
+			NumberedTreeNode<EmberElement>
+		>
 		safeSet(kidEl, kids, (x, y) => {
 			y.push(x)
 			return y
@@ -79,6 +77,7 @@ export function decodeGenericElement(
 
 	if (tag === null) {
 		unknownApplication(errors, 'decode generic element', tag, options)
+		skipNext(reader)
 		return makeResult(new NumberedTreeNodeImpl(-1, new EmberNodeImpl()), errors)
 	}
 	const isQualified = isTagQualified(tag)
@@ -97,26 +96,21 @@ export function decodeGenericElement(
 		)
 	}
 
-	const ber = reader.getSequence(tag)
+	reader.readSequence(tag)
 	let path: string | null = null
 	let number: number | null = null
 	let contents: EmberElement | null = null
 	let children: Array<NumberedTreeNode<EmberElement>> | undefined
 
-	while (ber.remain > 0) {
-		const tag = ber.peek()
-		if (tag === null) {
-			unknownContext(errors, 'decode generic element', tag, options)
-			continue
-		}
-		const seq = ber.getSequence(tag)
-
+	const endOffset = reader.offset + reader.length
+	while (reader.offset < endOffset) {
+		const tag = reader.readSequence()
 		switch (tag) {
 			case Ber.CONTEXT(0):
 				if (isQualified) {
-					path = seq.readRelativeOID()
+					path = reader.readRelativeOID()
 				} else {
-					number = seq.readInt()
+					number = reader.readInt()
 				}
 				break
 			case Ber.CONTEXT(1):
@@ -130,9 +124,10 @@ export function decodeGenericElement(
 							options
 						)
 						contents = new EmberNodeImpl()
+						skipNext(reader)
 						break
 					case ElementType.Function:
-						contents = appendErrors(decodeFunctionContent(seq, options), errors)
+						contents = appendErrors(decodeFunctionContent(reader, options), errors)
 						break
 					case ElementType.Matrix:
 						unknownApplication(
@@ -142,12 +137,13 @@ export function decodeGenericElement(
 							options
 						)
 						contents = new EmberNodeImpl()
+						skipNext(reader)
 						break
 					case ElementType.Node:
-						contents = appendErrors(decodeNode(seq, options), errors)
+						contents = appendErrors(decodeNode(reader, options), errors)
 						break
 					case ElementType.Parameter:
-						contents = appendErrors(decodeParameter(seq, options), errors)
+						contents = appendErrors(decodeParameter(reader, options), errors)
 						break
 					case ElementType.Template:
 						unknownApplication(
@@ -157,18 +153,21 @@ export function decodeGenericElement(
 							options
 						)
 						contents = new EmberNodeImpl()
+						skipNext(reader)
 						break
 					default:
 						unknownApplication(errors, 'decode generic element', tag, options)
 						contents = new EmberNodeImpl()
+						skipNext(reader)
 						break
 				}
 				break
 			case Ber.CONTEXT(2):
-				children = appendErrors(decodeChildren(seq, options), errors)
+				children = appendErrors(decodeChildren(reader, options), errors)
 				break
 			default:
 				unknownContext(errors, 'decode generic element', tag, options)
+				skipNext(reader)
 				break
 		}
 	}
@@ -203,15 +202,16 @@ export function decodeRootElements(
 	reader: Ber.Reader,
 	options: DecodeOptions = defaultDecode
 ): DecodeResult<Array<RootElement>> {
-	const seq = reader.getSequence(RootElementsBERID)
+	reader.readSequence(RootElementsBERID)
 	const rootEls = makeResult<Array<RootElement>>([])
-	while (seq.remain > 0) {
-		const tag = seq.peek()
+	const endOffset = reader.offset + reader.length
+	while (reader.offset < endOffset) {
+		const tag = reader.readSequence()
 		if (tag !== Ber.CONTEXT(0)) {
 			unknownContext(rootEls, 'decode root elements', tag, options)
+			skipNext(reader)
 		}
-		const data = seq.getSequence(Ber.CONTEXT(0))
-		const rootEl = decodeGenericElement(data, options) as DecodeResult<
+		const rootEl = decodeGenericElement(reader, options) as DecodeResult<
 			NumberedTreeNode<EmberElement>
 		>
 		safeSet(rootEl, rootEls, (x, y) => {

--- a/src/encodings/ber/index.ts
+++ b/src/encodings/ber/index.ts
@@ -69,20 +69,20 @@ function berDecode(b: Buffer, options: DecodeOptions = defaultDecode): DecodeRes
 		return makeResult([new NumberedTreeNodeImpl(-1, new EmberNodeImpl())], errors)
 	}
 
-	const rootSeq = reader.getSequence(tag)
-	const rootSeqType = rootSeq.peek()
+	reader.readSequence(tag)
+	const rootSeqType = reader.peek()
 
 	if (rootSeqType === RootElementsBERID) {
 		// RootElementCollection
-		const root: DecodeResult<Array<RootElement>> = decodeRootElements(rootSeq, options)
+		const root: DecodeResult<Array<RootElement>> = decodeRootElements(reader, options)
 		return root
 	} else if (rootSeqType === StreamEntriesBERID) {
 		// StreamCollection
-		const root: DecodeResult<Array<StreamEntry>> = decodeStreamEntries(rootSeq, options)
+		const root: DecodeResult<Array<StreamEntry>> = decodeStreamEntries(reader, options)
 		return root
 	} else if (rootSeqType === InvocationResultBERID) {
 		// InvocationResult
-		const root: DecodeResult<InvocationResult> = decodeInvocationResult(rootSeq, options)
+		const root: DecodeResult<InvocationResult> = decodeInvocationResult(reader, options)
 		return root
 	}
 


### PR DESCRIPTION
Based on what I believe was a misunderstanding of how the ASN.1 library works, the decoder was creating a new Ber.Reader for every sequence tag. This is not necessary when the decoder is reading linearly from start to finish. I have removed the `ExtendedReader.getSequence()` method and replaced this with the intended use of ASN.1 via `readSequence()` and `reader.length`. 

For large structures, this may improve performance because it significantly reduces the number of objects created and the amount of garbage that needs to be collected.