### PR TITLE
Fix/indefinite length

### DIFF
--- a/src/encodings/ber/__tests__/EmberNode.spec.ts
+++ b/src/encodings/ber/__tests__/EmberNode.spec.ts
@@ -5,6 +5,113 @@ import { decodeNode } from '../decoder/EmberNode'
 import { ElementType } from '../../../model/EmberElement'
 import { literal } from '../../../types/types'
 import { guarded } from '../decoder/DecodeResult'
+import { berDecode } from '../'
+import { decodeGenericElement } from '../decoder/Tree'
+
+const indefiniteLength = Buffer.from([
+	0x60,
+	0x80, // Root - length 60
+	0x6b,
+	0x80, // RootElements -- length 56
+	0xa0,
+	0x80, // First element - 52
+	0x6a,
+	0x80, // Qualified Node - length 48
+	0xa0,
+	0x03,
+	0x0d,
+	0x01,
+	0x01,
+	0xa2,
+	0x80, // Children length 39
+	0x64,
+	0x80, // ElementCollection length 35
+	0xa0,
+	0x80, // Element length 31
+	0x63,
+	0x80, // Node length 27
+	0xa0,
+	0x03,
+	0x02,
+	0x01,
+	0x01,
+	0xa1,
+	0x80, // Node Content length 20
+	0x31,
+	0x80, // set length 16 - Ber library measures 18
+	0xa0,
+	0x09,
+	0x0c,
+	0x07,
+	0x53,
+	0x6f,
+	0x75,
+	0x72,
+	0x63,
+	0x65,
+	0x73,
+	0xa3,
+	0x03,
+	0x01,
+	0x01,
+	0xff,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00
+])
+
+const nodeOnly = Buffer.from([
+	0x63,
+	0x80, // Node length 27
+	0xa0,
+	0x03,
+	0x02,
+	0x01,
+	0x01,
+	0xa1,
+	0x80, // Node Content length 20
+	0x31,
+	0x80, // set length 16 - Ber library measures 18
+	0xa0,
+	0x09,
+	0x0c,
+	0x07,
+	0x53,
+	0x6f,
+	0x75,
+	0x72,
+	0x63,
+	0x65,
+	0x73,
+	0xa3,
+	0x03,
+	0x01,
+	0x01,
+	0xff,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00,
+	0x00
+])
 
 describe('encodings/ber/EmberNode', () => {
 	const en = literal<EmberNode>({
@@ -25,5 +132,19 @@ describe('encodings/ber/EmberNode', () => {
 		const decoded = guarded(decodeNode(reader))
 
 		expect(decoded).toEqual(en)
+	})
+
+	test('decode indefinite length', () => {
+		const decoded = berDecode(indefiniteLength)
+
+		console.log(decoded.value)
+		expect(decoded.errors).toHaveLength(0)
+	})
+
+	test('decode indefinite node only', () => {
+		const reader = new Ber.Reader(nodeOnly)
+		const decoded = decodeGenericElement(reader)
+		console.log(decoded.value)
+		expect(decoded.errors).toHaveLength(0)
 	})
 })

--- a/src/encodings/ber/decoder/Command.ts
+++ b/src/encodings/ber/decoder/Command.ts
@@ -65,6 +65,8 @@ function decodeCommand(
 			case Ber.CONTEXT(2):
 				invocation = appendErrors(decodeInvocation(reader, options), errors)
 				break
+			case 0:
+				break // Indefinite lengths
 			default:
 				unknownContext(errors, 'decode command', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/Connection.ts
+++ b/src/encodings/ber/decoder/Connection.ts
@@ -52,6 +52,8 @@ function decodeConnection(
 			case Ber.CONTEXT(3):
 				disposition = appendErrors(readConnectionDisposition(reader.readInt(), options), errors)
 				break
+			case 0:
+				break // Indefinite lengths
 			default:
 				unknownContext(errors, 'decode connection', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/EmberFunction.ts
+++ b/src/encodings/ber/decoder/EmberFunction.ts
@@ -45,6 +45,7 @@ function decodeFunctionContent(
 				seqOffset = reader.offset + reader.length
 				while (reader.offset < seqOffset) {
 					const argTag = reader.readSequence()
+					if (argTag === 0) continue // indefinite length
 					if (argTag !== Ber.CONTEXT(0)) {
 						unknownContext(errors, 'decode function content: arguments', argTag, options)
 						skipNext(reader)
@@ -60,6 +61,7 @@ function decodeFunctionContent(
 				resOffset = reader.offset + reader.length
 				while (reader.offset < resOffset) {
 					const resTag = reader.readSequence()
+					if (resTag === 0) continue // indefinite length
 					if (resTag !== Ber.CONTEXT(0)) {
 						unknownContext(errors, 'decode function content: result', resTag, options)
 						skipNext(reader)
@@ -72,6 +74,8 @@ function decodeFunctionContent(
 			case Ber.CONTEXT(4):
 				templateReference = reader.readRelativeOID(Ber.BERDataTypes.RELATIVE_OID)
 				break
+			case 0:
+				break // Idefinite length
 			default:
 				unknownContext(errors, 'decode function content', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/EmberNode.ts
+++ b/src/encodings/ber/decoder/EmberNode.ts
@@ -47,8 +47,7 @@ function decodeNode(
 				templateReference = reader.readRelativeOID(Ber.BERDataTypes.RELATIVE_OID)
 				break
 			case 0:
-				console.log('*** decodeNode: found a zero tag')
-				break
+				break // indefinite length
 			default:
 				unknownContext(errors, 'deocde node', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/EmberNode.ts
+++ b/src/encodings/ber/decoder/EmberNode.ts
@@ -46,6 +46,9 @@ function decodeNode(
 			case Ber.CONTEXT(5):
 				templateReference = reader.readRelativeOID(Ber.BERDataTypes.RELATIVE_OID)
 				break
+			case 0:
+				console.log('*** decodeNode: found a zero tag')
+				break
 			default:
 				unknownContext(errors, 'deocde node', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/FunctionArgument.ts
+++ b/src/encodings/ber/decoder/FunctionArgument.ts
@@ -34,6 +34,8 @@ function decodeFunctionArgument(
 			case Ber.CONTEXT(1):
 				name = reader.readString(Ber.BERDataTypes.STRING)
 				break
+			case 0:
+				break // indefinite length
 			default:
 				unknownContext(errors, 'decode function context', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/Invocation.ts
+++ b/src/encodings/ber/decoder/Invocation.ts
@@ -38,6 +38,8 @@ function decodeInvocation(
 					args.push(reader.readValue())
 				}
 				break
+			case 0:
+				break // indefinite length
 			default:
 				unknownContext(errors, 'decode invocation', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/InvocationResult.ts
+++ b/src/encodings/ber/decoder/InvocationResult.ts
@@ -38,6 +38,7 @@ export function decodeInvocationResult(
 				seqOffset = reader.offset + reader.length
 				while (reader.offset < seqOffset) {
 					const resTag = reader.readSequence()
+					if (resTag === 0) continue
 					if (resTag === null || resTag !== Ber.CONTEXT(0)) {
 						unknownContext(errors, 'decode invocation result: result', resTag, options)
 						skipNext(reader)
@@ -46,6 +47,8 @@ export function decodeInvocationResult(
 					result.push(reader.readValue())
 				}
 				break
+			case 0:
+				break // indefinite length
 			default:
 				unknownContext(errors, 'decode invocation result', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/Label.ts
+++ b/src/encodings/ber/decoder/Label.ts
@@ -31,6 +31,8 @@ function decodeLabel(
 			case Ber.CONTEXT(1):
 				description = reader.readString(Ber.BERDataTypes.STRING)
 				break
+			case 0:
+				break // indefinite length
 			default:
 				unknownContext(errors, 'decode label', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/Matrix.ts
+++ b/src/encodings/ber/decoder/Matrix.ts
@@ -74,6 +74,8 @@ function decodeMatrix(
 			case Ber.CONTEXT(5):
 				connections = appendErrors(decodeConnections(reader, options), errors)
 				break
+			case 0:
+				break // indefinite length
 			default:
 				unknownContext(errors, 'decode matrix', tag, options)
 				skipNext(reader)
@@ -179,6 +181,8 @@ function decodeMatrixContents(
 			case Ber.CONTEXT(12):
 				templateReference = reader.readRelativeOID(Ber.BERDataTypes.RELATIVE_OID)
 				break
+			case 0:
+				break // indefinite length
 			default:
 				unknownContext(errors, 'decode mattric contents', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/Parameter.ts
+++ b/src/encodings/ber/decoder/Parameter.ts
@@ -106,6 +106,8 @@ function decodeParameter(
 			case Ber.CONTEXT(18):
 				templateReference = reader.readString(Ber.BERDataTypes.STRING)
 				break
+			case 0:
+				break // indefinite length
 			default:
 				unknownContext(errors, 'decode parameter', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/StreamDescription.ts
+++ b/src/encodings/ber/decoder/StreamDescription.ts
@@ -35,6 +35,8 @@ export function decodeStreamDescription(
 			case Ber.CONTEXT(1):
 				offset = reader.readInt()
 				break
+			case 0:
+				break // indefinite length
 			default:
 				unknownContext(errors, 'decode stream description', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/StreamEntry.ts
+++ b/src/encodings/ber/decoder/StreamEntry.ts
@@ -25,6 +25,7 @@ function decodeStreamEntries(
 	const endOffset = reader.offset + reader.length
 	while (reader.offset < endOffset) {
 		const tag = reader.readSequence()
+		if (tag === 0) continue
 		if (tag !== Ber.CONTEXT(0)) {
 			unknownContext(streamEntries, 'decode stream entries', tag, options)
 			skipNext(reader)
@@ -57,6 +58,8 @@ function decodeStreamEntry(
 			case Ber.CONTEXT(1):
 				value = reader.readValue()
 				break
+			case 0:
+				break // indefinite length
 			default:
 				unknownContext(errors, 'decode stream entry', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/StringIntegerCollection.ts
+++ b/src/encodings/ber/decoder/StringIntegerCollection.ts
@@ -24,6 +24,7 @@ function decodeStringIntegerCollection(
 	const endOffset = reader.offset + reader.length
 	while (reader.offset < endOffset) {
 		const tag = reader.readSequence()
+		if (tag === 0) continue
 		if (tag !== Ber.CONTEXT(0)) {
 			unknownContext(errors, 'decode string integer collection', tag, options)
 			skipNext(reader)
@@ -53,6 +54,8 @@ function decodeStringIntegerPair(
 			case Ber.CONTEXT(1):
 				value = reader.readInt()
 				break
+			case 0:
+				break // indefinite length
 			default:
 				unknownContext(errors, 'deocde string integer pair', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/Template.ts
+++ b/src/encodings/ber/decoder/Template.ts
@@ -52,6 +52,8 @@ export function decodeTemplate(
 			case Ber.CONTEXT(2):
 				description = reader.readString(Ber.BERDataTypes.STRING)
 				break
+			case 0:
+				break // indefinite length
 			default:
 				unknownContext(errors, 'decode template', tag, options)
 				skipNext(reader)

--- a/src/encodings/ber/decoder/Tree.ts
+++ b/src/encodings/ber/decoder/Tree.ts
@@ -55,7 +55,6 @@ export function decodeChildren(
 	)
 
 	const endOffset = reader.offset + reader.length
-	console.log(`Well hello my children ${reader.length}`)
 	while (reader.offset < endOffset) {
 		const tag = reader.readSequence()
 		if (tag === 0) continue
@@ -86,8 +85,6 @@ export function decodeGenericElement(
 	const isQualified = isTagQualified(tag)
 	const type = appendErrors(tagToElType(tag, options), errors)
 
-	console.log('++++ DANGER WILL ROBINSON +++++', tag, type)
-
 	if (tag === MatrixBERID || tag === QualifiedMatrixBERID) {
 		return decodeMatrix(reader, isQualified)
 	}
@@ -108,10 +105,8 @@ export function decodeGenericElement(
 	let children: Collection<NumberedTreeNode<EmberElement>> | undefined
 
 	const endOffset = reader.offset + reader.length
-	console.log(`Element length ${reader.length}`)
 	while (reader.offset < endOffset) {
 		const tag = reader.readSequence()
-		console.log(`Element with tag ${tag} has length ${reader.length}`)
 		switch (tag) {
 			case Ber.CONTEXT(0):
 				if (isQualified) {
@@ -148,7 +143,6 @@ export function decodeGenericElement(
 						break
 					case ElementType.Node:
 						contents = appendErrors(decodeNode(reader, options), errors)
-						console.dir(contents)
 						break
 					case ElementType.Parameter:
 						contents = appendErrors(decodeParameter(reader, options), errors)
@@ -174,8 +168,7 @@ export function decodeGenericElement(
 				children = appendErrors(decodeChildren(reader, options), errors)
 				break
 			case 0:
-				console.log('**** decodeGenericElement: Found a zero tag!!')
-				break
+				break // indefinite length
 			default:
 				unknownContext(errors, 'decode generic element', tag, options)
 				skipNext(reader)
@@ -227,7 +220,6 @@ export function decodeRootElements(
 	const rootEls = makeResult<Collection<RootElement>>({})
 
 	const endOffset = reader.offset + reader.length
-	console.log(`Root element BOO ${reader.length}`)
 	while (reader.offset < endOffset) {
 		const tag = reader.readSequence()
 		if (tag === 0) continue


### PR DESCRIPTION
Some Lawo EmberPlus packets were encountered that use two encoding patterns that the library itself does not follow, so were not picked up in round trip testing. These are:

1. Use of indefinite length almost everywhere, requiring the decoder to forward compute most lengths. The ASN.1 decoder library includes the terminating bytes `0x00 0x00` in its length and the decoder was not compensating for these.
2. A Qualified Node at the root of a tree only used to contain children and so lacking any _contents_.

This PR adds a test for the above based on Lawo data and attempts to fix both issues.