### PR TITLE
fix: Setting 2 full path properties fails SOFIE-2628

### DIFF
--- a/src/Ember/Client/__tests__/index.spec.ts
+++ b/src/Ember/Client/__tests__/index.spec.ts
@@ -1,0 +1,249 @@
+import {
+	NumberedTreeNode,
+	EmberElement,
+	NumberedTreeNodeImpl,
+	EmberNodeImpl,
+	ParameterImpl,
+	ParameterType,
+	QualifiedElementImpl,
+} from '../../../model'
+import { Collection, Root, RootElement } from '../../../types/types'
+import { EmberClient } from '../'
+import S101ClientMock from '../../../__mocks__/S101Client'
+import { DecodeResult } from '../../../encodings/ber/decoder/DecodeResult'
+// import { EmberTreeNode, RootElement } from '../../../types/types'
+// import { ElementType, EmberElement } from '../../../model/EmberElement'
+// import { Parameter, ParameterType } from '../../../model/Parameter'
+
+jest.mock('../../Socket/S101Client', () => require('../../../__mocks__/S101Client'))
+
+describe('client', () => {
+	const onSocketCreate = jest.fn()
+	const onConnection = jest.fn()
+	const onSocketClose = jest.fn()
+	const onSocketWrite = jest.fn()
+	const onConnectionChanged = jest.fn()
+
+	function setupSocketMock() {
+		S101ClientMock.mockOnNextSocket((socket: any) => {
+			onSocketCreate()
+
+			socket.onConnect = onConnection
+			socket.onWrite = onSocketWrite
+			socket.onClose = onSocketClose
+		})
+	}
+
+	beforeEach(() => {
+		setupSocketMock()
+	})
+	afterEach(() => {
+		const sockets = S101ClientMock.openSockets()
+		// Destroy any lingering sockets, to prevent a failing test from affecting other tests:
+		sockets.forEach((s) => s.destroy())
+
+		S101ClientMock.clearMockOnNextSocket()
+		onSocketCreate.mockClear()
+		onConnection.mockClear()
+		onSocketClose.mockClear()
+		onSocketWrite.mockClear()
+		onConnectionChanged.mockClear()
+
+		// Just a check to ensure that the unit tests cleaned up the socket after themselves:
+		// eslint-disable-next-line jest/no-standalone-expect
+		expect(sockets).toHaveLength(0)
+	})
+
+	async function runWithConnection(fn: (connection: EmberClient, socket: S101ClientMock) => Promise<void>) {
+		const client = new EmberClient('test')
+		try {
+			expect(client).toBeTruthy()
+
+			await client.connect()
+
+			// Wait for connection
+			await new Promise(setImmediate)
+
+			// Should be connected
+			expect(client.connected).toBeTruthy()
+
+			const sockets = S101ClientMock.openSockets()
+			expect(sockets).toHaveLength(1)
+			expect(onSocketWrite).toHaveBeenCalledTimes(0)
+
+			await fn(client, sockets[0])
+		} finally {
+			// Ensure cleaned up
+			await client.disconnect()
+			client.discard()
+
+			await new Promise(setImmediate)
+		}
+	}
+
+	function createQualifiedNodeResponse(
+		path: string,
+		content: EmberElement,
+		children: Collection<NumberedTreeNode<EmberElement>>
+	): DecodeResult<Root> {
+		const parent = new QualifiedElementImpl<EmberElement>(path, content, children)
+
+		const fixLevel = (node: NumberedTreeNode<EmberElement>, parent: NumberedTreeNode<EmberElement>) => {
+			node.parent = parent
+
+			for (const child of Object.values<NumberedTreeNode<EmberElement>>(node.children ?? {})) {
+				fixLevel(child, node)
+			}
+		}
+		for (const child of Object.values<NumberedTreeNode<EmberElement>>(children)) {
+			fixLevel(child, parent as any as NumberedTreeNode<EmberElement>)
+		}
+		return {
+			value: {
+				0: parent as Exclude<RootElement, NumberedTreeNode<EmberElement>>,
+			},
+		}
+	}
+
+	it('getDirectory resolves', async () => {
+		await runWithConnection(async (client, socket) => {
+			// Do initial load
+			const getRootDirReq = await client.getDirectory(client.tree)
+			getRootDirReq.response?.catch(() => null) // Ensure uncaught response is ok
+			expect(onSocketWrite).toHaveBeenCalledTimes(1)
+			// TODO: should the value of the call be checked?
+
+			// Mock a valid response
+			socket.mockData({
+				value: {
+					1: new NumberedTreeNodeImpl(1, new EmberNodeImpl('Ruby', undefined, undefined, true)),
+				},
+			})
+
+			// Should have a response
+			const res = (await getRootDirReq.response) as NumberedTreeNodeImpl<EmberElement>
+			expect(res).toMatchObject(new NumberedTreeNodeImpl(1, new EmberNodeImpl('Ruby', undefined, undefined, true)))
+		})
+	})
+
+	it('getElementByPath', async () => {
+		await runWithConnection(async (client, socket) => {
+			// Do initial load
+			const getRootDirReq = await client.getDirectory(client.tree)
+			getRootDirReq.response?.catch(() => null) // Ensure uncaught response is ok
+			expect(onSocketWrite).toHaveBeenCalledTimes(1)
+			onSocketWrite.mockClear()
+
+			// Mock a valid response
+			socket.mockData({
+				value: {
+					1: new NumberedTreeNodeImpl(1, new EmberNodeImpl('Ruby', undefined, undefined, true)),
+				},
+			})
+			await getRootDirReq.response
+
+			// Run the tree
+			const getByPathPromise = client.getElementByPath('Ruby.Sums.On')
+
+			// First lookup
+			expect(onSocketWrite).toHaveBeenCalledTimes(1)
+			socket.mockData({
+				value: {
+					1: new NumberedTreeNodeImpl(1, new EmberNodeImpl('Ruby', undefined, undefined, true), {
+						1: new NumberedTreeNodeImpl(1, new EmberNodeImpl('Sums', undefined, undefined, true)),
+					}),
+				},
+			})
+
+			await new Promise(setImmediate)
+
+			// Second lookup
+			expect(onSocketWrite).toHaveBeenCalledTimes(2)
+			socket.mockData({
+				value: {
+					1: new QualifiedElementImpl<EmberElement>('1.1', new EmberNodeImpl('Sums', undefined, undefined, false), {
+						1: new NumberedTreeNodeImpl(1, new ParameterImpl(ParameterType.Boolean, 'On', undefined, false)),
+					}) as Exclude<RootElement, NumberedTreeNode<EmberElement>>,
+				},
+			})
+
+			await new Promise(setImmediate)
+
+			const res = await getByPathPromise
+			expect(res).toBeTruthy()
+			expect(res).toMatchObject(
+				new NumberedTreeNodeImpl(1, new ParameterImpl(ParameterType.Boolean, 'On', undefined, false))
+			)
+		})
+	})
+
+	it('getElementByPath concurrent', async () => {
+		await runWithConnection(async (client, socket) => {
+			// Do initial load
+			const getRootDirReq = await client.getDirectory(client.tree)
+			getRootDirReq.response?.catch(() => null) // Ensure uncaught response is ok
+			expect(onSocketWrite).toHaveBeenCalledTimes(1)
+			onSocketWrite.mockClear()
+
+			// Mock a valid response
+			socket.mockData({
+				value: {
+					1: new NumberedTreeNodeImpl(1, new EmberNodeImpl('Ruby', undefined, undefined, true)),
+				},
+			})
+			await getRootDirReq.response
+
+			// Run the tree
+			const getByPathPromise = client.getElementByPath('Ruby.Sums.MAIN.On')
+			const getByPathPromise2 = client.getElementByPath('Ruby.Sums.MAIN.Second')
+
+			// First lookup from both
+			expect(onSocketWrite).toHaveBeenCalledTimes(2)
+			socket.mockData(
+				createQualifiedNodeResponse('1', new EmberNodeImpl('Ruby', undefined, undefined, true), {
+					1: new NumberedTreeNodeImpl(1, new EmberNodeImpl('Sums', undefined, undefined, false)),
+				})
+			)
+
+			socket.mockData(
+				createQualifiedNodeResponse('1', new EmberNodeImpl('Ruby', undefined, undefined, true), {
+					1: new NumberedTreeNodeImpl(1, new EmberNodeImpl('Sums', undefined, undefined, false)),
+				})
+			)
+
+			await new Promise(setImmediate)
+
+			// Second lookup
+			expect(onSocketWrite).toHaveBeenCalledTimes(4)
+			socket.mockData(
+				createQualifiedNodeResponse('1.1', new EmberNodeImpl('Sums', undefined, undefined, false), {
+					1: new NumberedTreeNodeImpl(1, new EmberNodeImpl('MAIN', undefined, undefined, false)),
+				})
+			)
+			await new Promise(setImmediate)
+			socket.mockData(
+				createQualifiedNodeResponse('1.1', new EmberNodeImpl('Sums', undefined, undefined, false), {
+					1: new NumberedTreeNodeImpl(1, new EmberNodeImpl('MAIN', undefined, undefined, false)),
+				})
+			)
+
+			await new Promise(setImmediate)
+
+			// Final lookup
+			expect(onSocketWrite).toHaveBeenCalledTimes(6)
+			socket.mockData(
+				createQualifiedNodeResponse('1.1.1', new EmberNodeImpl('MAIN', undefined, undefined, false), {
+					1: new NumberedTreeNodeImpl(1, new ParameterImpl(ParameterType.Boolean, 'On', undefined, false)),
+					2: new NumberedTreeNodeImpl(1, new ParameterImpl(ParameterType.Boolean, 'Second', undefined, false)),
+				})
+			)
+
+			// Both completed successfully
+			const res = await getByPathPromise
+			expect(res).toBeTruthy()
+
+			const res2 = await getByPathPromise2
+			expect(res2).toBeTruthy()
+		})
+	})
+})

--- a/src/Ember/Client/index.ts
+++ b/src/Ember/Client/index.ts
@@ -438,7 +438,7 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 		// insert command
 		const commandEmberNode = insertCommand(qualifiedEmberNode, command)
 		// send request
-		return this._sendRequest<T>(commandEmberNode, hasResponse)
+		return this._sendRequest<T>(commandEmberNode, expectResponse)
 	}
 
 	private async _sendRequest<T>(node: RootElement, expectResponse: ExpectResponse): RequestPromise<T> {
@@ -450,12 +450,12 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 
 		const message = berEncode([node], RootType.Elements)
 
-		if (hasResponse !== ExpectResponse.None) {
+		if (expectResponse !== ExpectResponse.None) {
 			const p = new Promise<T>((resolve, reject) => {
 				const request: Request = {
 					reqId,
 					node,
-					nodeResponse: hasResponse,
+					nodeResponse: expectResponse,
 					resolve,
 					reject,
 					message,

--- a/src/Ember/Client/index.ts
+++ b/src/Ember/Client/index.ts
@@ -43,9 +43,17 @@ export interface RequestPromiseArguments<T> {
 	response?: Promise<T>
 }
 
+export enum ExpectResponse {
+	None = 'none',
+	Any = 'any',
+	HasChildren = 'has-children',
+}
+
 export interface Request {
 	reqId: string
 	node: RootElement
+	// Basic validation of the response change
+	nodeResponse: ExpectResponse
 	resolve: (res: any) => void
 	reject: (err: Error) => void
 	cb?: (EmberNode: TreeElement<EmberElement>) => void
@@ -192,7 +200,7 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 					cb,
 				})
 
-			return this._sendRequest<Root>(new NumberedTreeNodeImpl(0, command))
+			return this._sendRequest<Root>(new NumberedTreeNodeImpl(0, command), ExpectResponse.Any)
 		}
 
 		if (cb)
@@ -201,7 +209,7 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 				cb,
 			})
 
-		return this._sendCommand<RootElement>(node, command)
+		return this._sendCommand<RootElement>(node, command, ExpectResponse.HasChildren)
 	}
 	async subscribe(
 		node: RootElement | Array<RootElement>,
@@ -220,7 +228,7 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 					cb,
 				})
 
-			return this._sendRequest<Root>(new NumberedTreeNodeImpl(0, command))
+			return this._sendRequest<Root>(new NumberedTreeNodeImpl(0, command), ExpectResponse.Any)
 		}
 
 		if (cb)
@@ -229,7 +237,7 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 				cb,
 			})
 
-		return this._sendCommand<void>(node, command, false)
+		return this._sendCommand<void>(node, command, ExpectResponse.None)
 	}
 	async unsubscribe(node: NumberedTreeNode<EmberElement> | Array<RootElement>): RequestPromise<Root | void> {
 		if (!node) {
@@ -246,10 +254,10 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 		}
 
 		if (Array.isArray(node)) {
-			return this._sendRequest<Root>(new NumberedTreeNodeImpl(0, command))
+			return this._sendRequest<Root>(new NumberedTreeNodeImpl(0, command), ExpectResponse.Any)
 		}
 
-		return this._sendCommand<void>(node, command, false)
+		return this._sendCommand<void>(node, command, ExpectResponse.None)
 	}
 	async invoke(
 		node: NumberedTreeNode<EmberFunction> | QualifiedElement<EmberFunction>,
@@ -268,7 +276,7 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 				args,
 			},
 		}
-		return this._sendCommand<InvocationResult>(node, command)
+		return this._sendCommand<InvocationResult>(node, command, ExpectResponse.Any)
 	}
 
 	/** Sending ember+ values */
@@ -287,7 +295,10 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 		// TODO - should other properties be scrapped?
 		qualifiedParam.contents.value = value
 
-		return this._sendRequest<TreeElement<Parameter>>(qualifiedParam, awaitResponse)
+		return this._sendRequest<TreeElement<Parameter>>(
+			qualifiedParam,
+			awaitResponse ? ExpectResponse.Any : ExpectResponse.None
+		)
 	}
 	async matrixConnect(
 		matrix: QualifiedElement<Matrix> | NumberedTreeNode<Matrix>,
@@ -355,24 +366,27 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 		cb?: (EmberNode: TreeElement<EmberElement>) => void,
 		delimiter = '.'
 	): Promise<TreeElement<EmberElement> | undefined> {
-		const getNext = (elements: Collection<NumberedTreeNode<EmberElement>>, i?: string) =>
+		const getNodeInCollection = (elements: Collection<NumberedTreeNode<EmberElement>>, identifier: string) =>
 			Object.values<NumberedTreeNode<EmberElement>>(elements || {}).find(
 				(r) =>
-					r.number === Number(i) ||
-					(r.contents as EmberNode).identifier === i ||
-					(r.contents as EmberNode).description === i
+					r.number === Number(identifier) ||
+					(r.contents as EmberNode).identifier === identifier ||
+					(r.contents as EmberNode).description === identifier
 			)
-		const getNextChild = (node: TreeElement<EmberElement>, i: string) => node.children && getNext(node.children, i)
+		const getNextChild = (node: TreeElement<EmberElement>, identifier: string) =>
+			node.children && getNodeInCollection(node.children, identifier)
 
 		const numberedPath: Array<number> = []
 		const pathArr = path.split(delimiter)
-		const i = pathArr.shift()
-		let tree: NumberedTreeNode<EmberElement> | undefined = getNext(this.tree, i)
-		if (tree?.number) numberedPath.push(tree?.number)
+		const firstIdentifier = pathArr.shift()
+		if (!firstIdentifier) throw new Error('Expected at least one segment in the path')
+
+		let tree: NumberedTreeNode<EmberElement> | undefined = getNodeInCollection(this.tree, firstIdentifier)
+		if (tree?.number !== undefined) numberedPath.push(tree.number)
 
 		while (pathArr.length) {
 			const i = pathArr.shift()
-			if (!i) break
+			if (!i) break // TODO - this will break the loop if the path was `1..0`
 			if (!tree) break
 			let next = getNextChild(tree, i)
 			if (!next) {
@@ -382,7 +396,7 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 			}
 			tree = next
 			if (!tree) throw new Error(`Could not find node ${i} on given path ${numberedPath.join()}`)
-			if (tree?.number) numberedPath.push(tree?.number)
+			if (tree?.number !== undefined) numberedPath.push(tree.number)
 		}
 
 		if (cb && numberedPath) {
@@ -415,19 +429,19 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 
 		qualifiedMatrix.contents.connections = [connection]
 
-		return this._sendRequest<TreeElement<Matrix>>(qualifiedMatrix)
+		return this._sendRequest<TreeElement<Matrix>>(qualifiedMatrix, ExpectResponse.Any)
 	}
 
-	private async _sendCommand<T>(EmberNode: RootElement, command: Command, hasResponse?: boolean) {
+	private async _sendCommand<T>(node: RootElement, command: Command, hasResponse: ExpectResponse) {
 		// assert a qualified EmberNode
-		const qualifiedEmberNode = assertQualifiedEmberNode(EmberNode)
+		const qualifiedEmberNode = assertQualifiedEmberNode(node)
 		// insert command
 		const commandEmberNode = insertCommand(qualifiedEmberNode, command)
 		// send request
 		return this._sendRequest<T>(commandEmberNode, hasResponse)
 	}
 
-	private async _sendRequest<T>(node: RootElement, hasResponse = true): RequestPromise<T> {
+	private async _sendRequest<T>(node: RootElement, hasResponse: ExpectResponse): RequestPromise<T> {
 		const reqId = Math.random().toString(24).substr(-4)
 		const requestPromise: RequestPromiseArguments<T> = {
 			reqId,
@@ -436,11 +450,12 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 
 		const message = berEncode([node], RootType.Elements)
 
-		if (hasResponse) {
+		if (hasResponse !== ExpectResponse.None) {
 			const p = new Promise<T>((resolve, reject) => {
 				const request: Request = {
 					reqId,
 					node,
+					nodeResponse: hasResponse,
 					resolve,
 					reject,
 					message,
@@ -489,6 +504,9 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 				(s) => (!('path' in s.node) && !change.path) || ('path' in s.node && s.node.path === change.path)
 			)
 			for (const req of reqs) {
+				// Don't complete the response, if the call was expecting the children to be loaded
+				if (req.nodeResponse === ExpectResponse.HasChildren && !change.node.children) continue
+
 				if (req.cb) req.cb(change.node)
 				if (req.resolve) {
 					req.resolve(change.node)

--- a/src/Ember/Client/index.ts
+++ b/src/Ember/Client/index.ts
@@ -432,7 +432,7 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 		return this._sendRequest<TreeElement<Matrix>>(qualifiedMatrix, ExpectResponse.Any)
 	}
 
-	private async _sendCommand<T>(node: RootElement, command: Command, hasResponse: ExpectResponse) {
+	private async _sendCommand<T>(node: RootElement, command: Command, expectResponse: ExpectResponse) {
 		// assert a qualified EmberNode
 		const qualifiedEmberNode = assertQualifiedEmberNode(node)
 		// insert command
@@ -441,7 +441,7 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 		return this._sendRequest<T>(commandEmberNode, hasResponse)
 	}
 
-	private async _sendRequest<T>(node: RootElement, hasResponse: ExpectResponse): RequestPromise<T> {
+	private async _sendRequest<T>(node: RootElement, expectResponse: ExpectResponse): RequestPromise<T> {
 		const reqId = Math.random().toString(24).substr(-4)
 		const requestPromise: RequestPromiseArguments<T> = {
 			reqId,

--- a/src/Ember/Server/index.ts
+++ b/src/Ember/Server/index.ts
@@ -60,7 +60,7 @@ export class EmberServer extends EventEmitter<EmberServerEvents> {
 		this._server.on('connection', (client: S101Socket) => {
 			this._clients.add(client)
 
-			client.on('emberTree', (tree: DecodeResult<Collection<RootElement>>) => this._handleIncoming(tree, client))
+			client.on('emberTree', (tree) => this._handleIncoming(tree as DecodeResult<Collection<RootElement>>, client))
 
 			client.on('error', (e) => {
 				this.emit('clientError', client, e)

--- a/src/Ember/Socket/S101Client.ts
+++ b/src/Ember/Socket/S101Client.ts
@@ -105,12 +105,12 @@ export default class S101Client extends S101Socket {
 		return super.disconnect(timeout)
 	}
 
-	handleClose(): void {
+	protected handleClose(): void {
 		if (this.keepaliveIntervalTimer) clearInterval(this.keepaliveIntervalTimer)
 		this.socket?.destroy()
 	}
 
-	_autoReconnectionAttempt(): void {
+	private _autoReconnectionAttempt(): void {
 		if (this._autoReconnect) {
 			if (this._reconnectAttempts > 0) {
 				// no reconnection if no valid reconnectionAttemps is set

--- a/src/__mocks__/S101Client.ts
+++ b/src/__mocks__/S101Client.ts
@@ -1,0 +1,109 @@
+import { ConnectionStatus } from '../Ember/Client'
+import type OrigS101Client from '../Ember/Socket/S101Client'
+import { EventEmitter } from 'eventemitter3'
+import { S101SocketEvents } from '../Ember/Socket/S101Socket'
+import { DecodeResult } from '../encodings/ber/decoder/DecodeResult'
+import { Root } from '../types'
+const sockets: Array<S101Client> = []
+const onNextSocket: Array<(socket: S101Client) => void> = []
+
+const orgSetImmediate = setImmediate
+
+export default class S101Client
+	extends EventEmitter<S101SocketEvents>
+	implements
+		Omit<
+			OrigS101Client,
+			// EventEmitter:
+			'on' | 'off' | 'once' | 'addListener' | 'removeListener' | 'removeAllListeners'
+		>
+{
+	public onWrite?: (data: Buffer) => boolean
+	public onConnect?: () => void
+	public onDisconnect?: () => void
+	public onClose?: () => void
+
+	address: string
+	port: number
+	autoConnect = false
+
+	public destroyed = false
+
+	status: ConnectionStatus = ConnectionStatus.Disconnected
+
+	constructor(address: string, port = 9000, autoConnect?: boolean) {
+		super()
+
+		this.address = address
+		this.port = port
+
+		this.autoConnect = !!autoConnect
+
+		const cb = onNextSocket.shift()
+		if (cb) {
+			cb(this)
+		}
+
+		sockets.push(this)
+
+		if (this.autoConnect) this.connect().catch(() => null) // errors are already emitted
+	}
+	async connect(_timeout?: number): Promise<void | Error> {
+		this.status = ConnectionStatus.Connecting
+
+		if (this.onConnect) this.onConnect()
+		orgSetImmediate(() => {
+			this.setConnected()
+		})
+	}
+	async disconnect(_timeout?: number | undefined): Promise<void> {
+		if (this.onConnect) this.onConnect()
+		orgSetImmediate(() => {
+			this.setDisconnected()
+		})
+	}
+
+	sendBER(data: Buffer): boolean {
+		if (this.onWrite) {
+			return this.onWrite(data) ?? true
+		} else {
+			return true
+		}
+	}
+
+	public static mockSockets(): S101Client[] {
+		return sockets
+	}
+	public static openSockets(): S101Client[] {
+		return sockets.filter((s) => !s.destroyed)
+	}
+	public static mockOnNextSocket(cb: (s: S101Client) => void): void {
+		onNextSocket.push(cb)
+	}
+	public static clearMockOnNextSocket(): void {
+		onNextSocket.splice(0, 99999)
+	}
+
+	public mockClose(): void {
+		this.setDisconnected()
+	}
+	public mockData(tree: DecodeResult<Root>): void {
+		this.emit('emberTree', tree)
+	}
+
+	public destroy(): void {
+		this.destroyed = true
+	}
+
+	private setConnected() {
+		this.destroyed = false
+		this.status = ConnectionStatus.Connected
+		this.emit('connected')
+	}
+	private setDisconnected() {
+		this.destroyed = true
+		this.status = ConnectionStatus.Disconnected
+		this.emit('disconnected')
+		if (this.onClose) this.onClose()
+	}
+}


### PR DESCRIPTION
I think what is happening is:
* Receive getDirectory for '1.1' (first setValue)
  * update node 1.1
  * report change to 1.1
  * create node 1.1.1
* Receive getDirectory for '1.1' (second setValue)
  * update node 1.1
  * report change to 1.1
  * update node 1.1.1
  * report change to 1.1.1

The change detection logic is pretty naive and isnt factoring in that `getDirectory` is expecting the `children` property to be loaded.
So the first 'change' which is updating solely the `contents` is completing the request, and confusing the `getElementByPath` which is expecting the children object to have been loaded by the time that the `getDirectory` call resolves.

-----

The change here introduces a simple enum, so that the `getDirectory` request can flag as needing the children to be loaded before it can be resolved. Other calls should behave the same as before, with the previous `hasResponse` being replaced with values in this enum