### PR TITLE
fix getDirectory for parameters

### DIFF
--- a/src/Ember/Client/index.ts
+++ b/src/Ember/Client/index.ts
@@ -404,12 +404,13 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 			const req = await this.getDirectory(tree)
 		}
 
-		if (cb && numberedPath) {
-			this._subscriptions.push({
-				path: numberedPath.join('.'),
-				cb,
-			})
-		}
+		// this resulted in doubled subscription because getDirectory() adds the element as well
+		// if (cb && numberedPath) {
+		// 	this._subscriptions.push({
+		// 		path: numberedPath.join('.'),
+		// 		cb,
+		// 	})
+		// }
 
 		return tree
 	}
@@ -511,7 +512,7 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 			for (const req of reqs) {
 				// Don't complete the response, if the call was expecting the children to be loaded
 				if (req.nodeResponse === ExpectResponse.HasChildren && !change.node.children) continue
-				
+
 				if (req.cb) req.cb(change.node)
 				if (req.resolve) {
 					req.resolve(change.node)

--- a/src/encodings/ber/encoder/Tree.ts
+++ b/src/encodings/ber/encoder/Tree.ts
@@ -130,7 +130,6 @@ function hasChildren(el: TreeElement<EmberElement>): boolean {
 		el.children !== undefined &&
 		!(
 			el.contents.type === ElementType.Command ||
-			el.contents.type === ElementType.Parameter ||
 			el.contents.type === ElementType.Template
 		)
 	)


### PR DESCRIPTION
# About the Contributor

This pull request is posted on behalf of NEP Germany.
 
# Type of Contribution

This is a: Bug fix

# Current Behavior

In current releases of Lawo MC square devices you need to explicitly send a "Get Directory" request down to the parameter in order to get updates from the device. This is not the case. The "getElementByPath()" request currently only requests until the parent of the specified node.

# New Behavior

"getElementByPath()" now explicitly requests the whole specified path. This fixes the problem, that sometimes no update is received from specific parameters

# Status

[ x ] PR is ready to be reviewed.
[ x ] The functionality has been tested by the author.
[ x ] Relevant unit tests has been added / updated.
[ x ] Relevant documentation (code comments, [system documentation](https://nrkno.github.io/sofie-core/)) has been added / updated.