### PR TITLE
Various fixes around responses with no children

### DIFF
--- a/src/Ember/Client/index.ts
+++ b/src/Ember/Client/index.ts
@@ -401,6 +401,12 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 			if (tree?.number !== undefined) numberedPath.push(tree.number)
 		}
 
+		if (tree?.contents.type === ElementType.Parameter) {
+			// do an additional getDirectory because Providers do not _have_ to send updates without that (should vs shall)
+			const req = await this.getDirectory(tree)
+			await req.response
+		}
+
 		if (cb && numberedPath) {
 			this._subscriptions.push({
 				path: numberedPath.join('.'),

--- a/src/Ember/Client/index.ts
+++ b/src/Ember/Client/index.ts
@@ -29,7 +29,7 @@ import { Connection, ConnectionDisposition, ConnectionOperation } from '../../mo
 import { EmberNode } from '../../model/EmberNode'
 import { EventEmitter } from 'eventemitter3'
 import { S101Client } from '../Socket'
-import { getPath, assertQualifiedEmberNode, insertCommand, updateProps } from '../Lib/util'
+import { getPath, assertQualifiedEmberNode, insertCommand, updateProps, isEmptyNode } from '../Lib/util'
 import { berEncode } from '../..'
 import { NumberedTreeNodeImpl } from '../../model/Tree'
 import { EmberFunction } from '../../model/EmberFunction'
@@ -70,6 +70,7 @@ export interface Subscription {
 export interface Change {
 	path: string | undefined
 	node: RootElement
+	emptyNode?: boolean
 }
 
 export enum ConnectionStatus {
@@ -209,7 +210,7 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 				cb,
 			})
 
-		return this._sendCommand<RootElement>(node, command, ExpectResponse.Any)
+		return this._sendCommand<RootElement>(node, command, ExpectResponse.HasChildren)
 	}
 	async subscribe(
 		node: RootElement | Array<RootElement>,
@@ -513,7 +514,15 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 			)
 			for (const req of reqs) {
 				// Don't complete the response, if the call was expecting the children to be loaded
-				if (req.nodeResponse === ExpectResponse.HasChildren && !change.node.children) continue
+				if (req.nodeResponse === ExpectResponse.HasChildren && !change.node.children) {
+					if (change.node.contents.type === ElementType.Parameter) {
+						// can't have children, therefore don't continue
+					} else if (change.emptyNode) {
+						// update comes from an empty node, so we can't continue anyway
+					} else {
+						continue
+					}
+				}
 
 				if (req.cb) req.cb(change.node)
 				if (req.resolve) {
@@ -603,6 +612,9 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 							this.tree[rootElement.number] = rootElement
 							changes.push({ path: undefined, node: rootElement })
 						}
+					} else if (isEmptyNode(rootElement)) {
+						// empty node on the root of the tree must mean we have done a getDir on that specific node
+						changes.push({ path: rootElement.number + '', node: rootElement, emptyNode: true })
 					} else {
 						// this must have been something on the root of the tree (like GetDirectory)
 						this.tree[rootElement.number] = rootElement
@@ -619,7 +631,8 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 		const changes: Array<Change> = []
 
 		if (update.contents.type === tree.contents.type) {
-			changes.push({ path: getPath(tree), node: tree })
+			changes.push({ path: getPath(tree), node: tree, emptyNode: isEmptyNode(update) })
+			// changes.push({ path: getPath(tree), node: tree })
 			switch (tree.contents.type) {
 				case ElementType.Node:
 					this._updateEmberNode(update.contents as EmberNode, tree.contents)
@@ -642,6 +655,9 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 		} else if (update.children) {
 			changes.push({ path: getPath(tree), node: tree })
 			tree.children = update.children
+			for (const c of Object.values<NumberedTreeNode<EmberElement>>(update.children)) {
+				c.parent = tree
+			}
 		}
 
 		return changes

--- a/src/Ember/Client/index.ts
+++ b/src/Ember/Client/index.ts
@@ -209,7 +209,7 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 				cb,
 			})
 
-		return this._sendCommand<RootElement>(node, command, ExpectResponse.HasChildren)
+		return this._sendCommand<RootElement>(node, command, ExpectResponse.Any)
 	}
 	async subscribe(
 		node: RootElement | Array<RootElement>,
@@ -386,8 +386,9 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 
 		while (pathArr.length) {
 			const i = pathArr.shift()
-			if (!i) break // TODO - this will break the loop if the path was `1..0`
+			if (i === undefined) break // TODO - this will break the loop if the path was `1..0`
 			if (!tree) break
+
 			let next = getNextChild(tree, i)
 			if (!next) {
 				const req = await this.getDirectory(tree)
@@ -395,6 +396,7 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 				next = getNextChild(tree, i)
 			}
 			tree = next
+
 			if (!tree) throw new Error(`Could not find node ${i} on given path ${numberedPath.join()}`)
 			if (tree?.number !== undefined) numberedPath.push(tree.number)
 		}

--- a/src/Ember/Client/index.ts
+++ b/src/Ember/Client/index.ts
@@ -590,9 +590,15 @@ export class EmberClient extends EventEmitter<EmberClientEvents> {
 					if (inserted) continue
 					changes.push(...this._updateTree(rootElement, tree))
 				} else {
-					if (this.tree[rootElement.number]) {
-						changes.push(...this._updateTree(rootElement, this.tree[rootElement.number]))
+					if (rootElement.children) {
+						if (this.tree[rootElement.number]) {
+							changes.push(...this._updateTree(rootElement, this.tree[rootElement.number]))
+						} else {
+							this.tree[rootElement.number] = rootElement
+							changes.push({ path: undefined, node: rootElement })
+						}
 					} else {
+						// this must have been something on the root of the tree (like GetDirectory)
 						this.tree[rootElement.number] = rootElement
 						changes.push({ path: undefined, node: rootElement })
 					}

--- a/src/Ember/Lib/util.ts
+++ b/src/Ember/Lib/util.ts
@@ -2,6 +2,7 @@ import { QualifiedElement, NumberedTreeNode, RootElement } from '../../types/typ
 import { EmberElement, ElementType } from '../../model/EmberElement'
 import { Command } from '../../model/Command'
 import { QualifiedElementImpl, NumberedTreeNodeImpl, TreeElement } from '../../model/Tree'
+import { EmberNode } from '../../model'
 
 export function assertQualifiedEmberNode(node: RootElement): Exclude<RootElement, NumberedTreeNode<EmberElement>> {
 	if ('path' in node) {
@@ -75,4 +76,32 @@ export function normalizeError(e: unknown): Error {
 	}
 
 	return new Error(typeof e === 'string' ? e : (e as any)?.toString())
+}
+
+export function isEmptyNode(node: TreeElement<EmberElement>): boolean {
+	const isNode = (node: TreeElement<EmberElement>): node is TreeElement<EmberNode> => {
+		return node.contents.type === ElementType.Node
+	}
+
+	if (!isNode(node)) {
+		return false
+	}
+
+	if (node.children) {
+		return false
+	}
+
+	if (
+		node.contents.description ??
+		node.contents.identifier ??
+		node.contents.isOnline ??
+		node.contents.isRoot ??
+		node.contents.schemaIdentifiers ??
+		node.contents.templateReference
+	) {
+		return false
+	}
+
+	// node is a node, node has no children, node has no properties set => node must be empty
+	return true
 }

--- a/src/Ember/Server/index.ts
+++ b/src/Ember/Server/index.ts
@@ -11,6 +11,7 @@ import {
 	MatrixImpl,
 	Matrix,
 	Connections,
+	EmberNodeImpl,
 } from '../../model'
 import {
 	Collection,
@@ -367,6 +368,10 @@ export class EmberServer extends EventEmitter<EmberServerEvents> {
 						qualified.children[i as unknown as number] = new NumberedTreeNodeImpl(child.number, child.contents)
 					}
 				}
+			} else if (qualified.contents.type === ElementType.Node && !('children' in tree && tree.children)) {
+				// node without children -> none of the properties should be set
+				qualified.contents = new EmberNodeImpl()
+				qualified.children = undefined
 			}
 			const data = berEncode([qualified as RootElement], RootType.Elements)
 			client.sendBER(data)

--- a/src/encodings/ber/encoder/Tree.ts
+++ b/src/encodings/ber/encoder/Tree.ts
@@ -128,11 +128,7 @@ function hasChildren(el: TreeElement<EmberElement>): boolean {
 	return (
 		'children' in el &&
 		el.children !== undefined &&
-		!(
-			el.contents.type === ElementType.Command ||
-			el.contents.type === ElementType.Parameter ||
-			el.contents.type === ElementType.Template
-		)
+		!(el.contents.type === ElementType.Command || el.contents.type === ElementType.Template)
 	)
 }
 


### PR DESCRIPTION
## Type of Contribution


Bug fix

## Current Behavior

- Calling getDirectory on the root of the tree more than once causes a timeout
- Calling getDirectory on parameters(?) or empty nodes fails because we expect children to be returned
- Empty nodes are sent out by the provider with all parameters set which is against the spec


## New Behavior

- Can call getDirectory on the root multiple times 
- Can call getDirectory on parameters and empty nodes
- Empty nodes are sent out by the provider with all parameters removed as in line with the ember+ documentation



