### PR TITLE
Fix fixed length for slicing when handling updates

### DIFF
--- a/src/Ember/Server/index.ts
+++ b/src/Ember/Server/index.ts
@@ -122,7 +122,12 @@ export class EmberServer extends EventEmitter<EmberServerEvents> {
 		const data = berEncode([el], RootType.Elements)
 		let elPath = el.path
 		if (el.contents.type !== ElementType.Node && !('targets' in update || 'sources' in update)) {
-			elPath = elPath.slice(0, -2) // remove the last element number
+			const lastDotIndex = elPath.lastIndexOf('.')
+			if (lastDotIndex > -1) {
+				elPath = elPath.slice(0, lastDotIndex)
+			} else {
+				elPath = ''
+			}
 		}
 
 		for (const [path, clients] of Object.entries<S101Socket[]>(this._subscriptions)) {


### PR DESCRIPTION
Original code uses fixed lenght when solving folder number. With fixed slicing, parameter 1.10 causes folder resolving to output "1." instead of "1"

This PR fixes the problem and doesn't use fixed slicing