### PR TITLE
Backport commit 3722d65 to v0.2.x branch

### DIFF
--- a/src/Ember/Server/index.ts
+++ b/src/Ember/Server/index.ts
@@ -122,7 +122,12 @@ export class EmberServer extends EventEmitter<EmberServerEvents> {
 		const data = berEncode([el], RootType.Elements)
 		let elPath = el.path
 		if (el.contents.type !== ElementType.Node && !('targets' in update || 'sources' in update)) {
-			elPath = elPath.slice(0, -2) // remove the last element number
+			const lastDotIndex = elPath.lastIndexOf('.')
+			if (lastDotIndex > -1) {
+				elPath = elPath.slice(0, lastDotIndex)
+			} else {
+				elPath = ''
+			}
 		}
 
 		for (const [path, clients] of Object.entries<S101Socket[]>(this._subscriptions)) {


### PR DESCRIPTION
<!--
Before you open a PR, be sure to read our Contribution guidelines:
https://Sofie-Automation.github.io/sofie-core/docs/for-developers/contribution-guidelines
-->

## About the Contributor

This pull request is posted on behalf of the Bitfocus Companion project.

## Type of Contribution

This is a:

<!-- (pick one) -->

Bug fix

## Current Behavior

Original code uses fixed length when solving folder number. With fixed slicing, parameter 1.10 causes folder resolving to output "1." instead of "1"

This PR backports commit `3722d65` to the `v0.2.x` branch.
## New Behavior

This change ensures that for a parameter at path '1.10', the subscription path is correctly set to '1', allowing the server to find and send the update to the subscribing client.

## Testing Instructions

<!--
Please provide some instructions and other information for how to verify that the feature works.
Examples:
* "Do a Take for a part that contains an adlib, verify that the adlib plays out."
* "Open the Switchboard panel and toggle a route, verify that the route toggles in the GUI."
* "This feature also affects 'feature X', so that needs to be tested for regressions as well."
-->

## Other Information

Original PR authored by  @jonnelaakso


## Status

<!--
Before you open the PR, make sure the items below are done.
If they're not, please open the PR as a Draft.
-->

- [X] PR is ready to be reviewed.
- [X] The functionality has been tested by the author.
- [ ] Relevant unit tests has been added / updated.
- [ ] Relevant documentation (code comments, [system documentation](https://Sofie-Automation.github.io/sofie-core/)) has been added / updated.
